### PR TITLE
Add initial Rust workspace with FFI bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ git submodule update --init libs/quiche-patched
 If the fetch fails, verify that the URL in `.gitmodules` points to a
 repository that hosts the required commit.
 
+### Rust Workspace
+
+The `rust/` directory contains a Cargo workspace with crates mirroring the C++ modules. Each crate builds C++ sources via the `cc` crate, enabling gradual migration.
+
+Build the Rust workspace with:
+
+```bash
+cd rust
+cargo build
+```
+
 
 ## 📜 License
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace]
+members = ["core", "crypto", "fec", "stealth"]

--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "quicfuscate-core"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[build-dependencies]
+cc = "1.0"

--- a/rust/core/build.rs
+++ b/rust/core/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    cc::Build::new()
+        .cpp(true)
+        .file("src/ffi.cpp")
+        .include("../../core")
+        .flag_if_supported("-std=c++17")
+        .compile("coreffi");
+}

--- a/rust/core/src/ffi.cpp
+++ b/rust/core/src/ffi.cpp
@@ -1,0 +1,4 @@
+#include "../../../core/error_handling.hpp"
+extern "C" int quic_error_success_code() {
+    return static_cast<int>(quicfuscate::ErrorCode::SUCCESS);
+}

--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -1,0 +1,7 @@
+extern "C" {
+    fn quic_error_success_code() -> i32;
+}
+
+pub fn success_code() -> i32 {
+    unsafe { quic_error_success_code() }
+}

--- a/rust/crypto/Cargo.toml
+++ b/rust/crypto/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "quicfuscate-crypto"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[build-dependencies]
+cc = "1.0"

--- a/rust/crypto/build.rs
+++ b/rust/crypto/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    cc::Build::new()
+        .cpp(true)
+        .file("../../crypto/morus.cpp")
+        .file("src/ffi.cpp")
+        .include("../../crypto")
+        .flag_if_supported("-std=c++17")
+        .compile("cryptoffi");
+}

--- a/rust/crypto/src/ffi.cpp
+++ b/rust/crypto/src/ffi.cpp
@@ -1,0 +1,17 @@
+#include "../../../crypto/morus.hpp"
+using namespace quicfuscate::crypto;
+extern "C" {
+MORUS* morus_new() { return new MORUS(); }
+void morus_free(MORUS* m) { delete m; }
+void morus_encrypt(MORUS* m,
+                   const uint8_t* plaintext,
+                   size_t plaintext_len,
+                   const uint8_t* key,
+                   const uint8_t* nonce,
+                   const uint8_t* ad,
+                   size_t ad_len,
+                   uint8_t* ciphertext,
+                   uint8_t* tag) {
+    m->encrypt(plaintext, plaintext_len, key, nonce, ad, ad_len, ciphertext, tag);
+}
+}

--- a/rust/crypto/src/lib.rs
+++ b/rust/crypto/src/lib.rs
@@ -1,0 +1,57 @@
+use std::os::raw::{c_uint,c_uchar,c_void};
+
+extern "C" {
+    fn morus_new() -> *mut c_void;
+    fn morus_free(ptr: *mut c_void);
+    fn morus_encrypt(
+        ctx: *mut c_void,
+        plaintext: *const c_uchar,
+        plaintext_len: usize,
+        key: *const c_uchar,
+        nonce: *const c_uchar,
+        ad: *const c_uchar,
+        ad_len: usize,
+        ciphertext: *mut c_uchar,
+        tag: *mut c_uchar,
+    );
+}
+
+pub struct Morus {
+    inner: *mut c_void,
+}
+
+impl Morus {
+    pub fn new() -> Self {
+        unsafe { Self { inner: morus_new() } }
+    }
+
+    pub fn encrypt(
+        &self,
+        plaintext: &[u8],
+        key: &[u8],
+        nonce: &[u8],
+        ad: &[u8],
+        ciphertext: &mut [u8],
+        tag: &mut [u8],
+    ) {
+        unsafe {
+            morus_encrypt(
+                self.inner,
+                plaintext.as_ptr(),
+                plaintext.len(),
+                key.as_ptr(),
+                nonce.as_ptr(),
+                ad.as_ptr(),
+                ad.len(),
+                ciphertext.as_mut_ptr(),
+                tag.as_mut_ptr(),
+            );
+        }
+    }
+}
+
+impl Drop for Morus {
+    fn drop(&mut self) {
+        unsafe { morus_free(self.inner) }
+    }
+}

--- a/rust/fec/Cargo.toml
+++ b/rust/fec/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quicfuscate-fec"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[build-dependencies]
+cc = "1.0"
+
+[dependencies]
+libc = "0.2"

--- a/rust/fec/build.rs
+++ b/rust/fec/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    cc::Build::new()
+        .cpp(true)
+        .file("../../fec/FEC_Modul.cpp")
+        .include("../../fec")
+        .flag_if_supported("-std=c++17")
+        .flag_if_supported("-fopenmp")
+        .flag_if_supported("-mavx2")
+        .compile("fecffi");
+}

--- a/rust/fec/src/lib.rs
+++ b/rust/fec/src/lib.rs
@@ -1,0 +1,24 @@
+use std::os::raw::{c_int, c_uchar, c_void};
+use libc;
+
+extern "C" {
+    fn fec_module_init() -> c_int;
+    fn fec_module_cleanup();
+    fn fec_module_encode(data: *const c_uchar, data_size: usize, out: *mut *mut c_uchar, out_size: *mut usize) -> c_int;
+}
+
+pub fn init() -> i32 { unsafe { fec_module_init() as i32 } }
+pub fn cleanup() { unsafe { fec_module_cleanup() } }
+
+pub fn encode(data: &[u8]) -> Option<Vec<u8>> {
+    unsafe {
+        let mut out_ptr: *mut u8 = std::ptr::null_mut();
+        let mut out_len: usize = 0;
+        let res = fec_module_encode(data.as_ptr(), data.len(), &mut out_ptr, &mut out_len);
+        if res != 0 { return None; }
+        let slice = std::slice::from_raw_parts(out_ptr, out_len);
+        let vec = slice.to_vec();
+        libc::free(out_ptr as *mut c_void);
+        Some(vec)
+    }
+}

--- a/rust/stealth/Cargo.toml
+++ b/rust/stealth/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quicfuscate-stealth"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[build-dependencies]
+cc = "1.0"
+
+[dependencies]
+libc = "0.2"

--- a/rust/stealth/build.rs
+++ b/rust/stealth/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    cc::Build::new()
+        .cpp(true)
+        .file("../../stealth/XOR_Obfuscation.cpp")
+        .file("src/ffi.cpp")
+        .include("../../stealth")
+        .flag_if_supported("-std=c++17")
+        .compile("stealthffi");
+}

--- a/rust/stealth/src/ffi.cpp
+++ b/rust/stealth/src/ffi.cpp
@@ -1,0 +1,22 @@
+#include "../../../stealth/XOR_Obfuscation.hpp"
+#include <cstdlib>
+#include <cstring>
+using namespace quicfuscate::stealth;
+extern "C" {
+XORObfuscator* xor_obfuscator_new() { return new XORObfuscator(); }
+void xor_obfuscator_free(XORObfuscator* x) { delete x; }
+int xor_obfuscator_obfuscate(XORObfuscator* x,
+                             const uint8_t* data,
+                             size_t len,
+                             uint8_t** out,
+                             size_t* out_len) {
+    if(!x || !data || !out || !out_len) return -1;
+    std::vector<uint8_t> input(data, data + len);
+    auto result = x->obfuscate(input);
+    *out_len = result.size();
+    *out = (uint8_t*)malloc(result.size());
+    if(!*out) return -1;
+    memcpy(*out, result.data(), result.size());
+    return 0;
+}
+}

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -1,0 +1,47 @@
+use std::os::raw::{c_int, c_uchar, c_void};
+use libc;
+
+extern "C" {
+    fn xor_obfuscator_new() -> *mut c_void;
+    fn xor_obfuscator_free(ptr: *mut c_void);
+    fn xor_obfuscator_obfuscate(
+        ptr: *mut c_void,
+        data: *const c_uchar,
+        len: usize,
+        out: *mut *mut c_uchar,
+        out_len: *mut usize,
+    ) -> c_int;
+}
+
+pub struct XorObfuscator {
+    inner: *mut c_void,
+}
+
+impl XorObfuscator {
+    pub fn new() -> Self {
+        unsafe { Self { inner: xor_obfuscator_new() } }
+    }
+
+    pub fn obfuscate(&self, data: &[u8]) -> Option<Vec<u8>> {
+        unsafe {
+            let mut out_ptr: *mut u8 = std::ptr::null_mut();
+            let mut out_len: usize = 0;
+            let res = xor_obfuscator_obfuscate(
+                self.inner,
+                data.as_ptr(),
+                data.len(),
+                &mut out_ptr,
+                &mut out_len,
+            );
+            if res != 0 { return None; }
+            let slice = std::slice::from_raw_parts(out_ptr, out_len);
+            let vec = slice.to_vec();
+            libc::free(out_ptr as *mut c_void);
+            Some(vec)
+        }
+    }
+}
+
+impl Drop for XorObfuscator {
+    fn drop(&mut self) { unsafe { xor_obfuscator_free(self.inner) } }
+}

--- a/stealth/XOR_Obfuscation.hpp
+++ b/stealth/XOR_Obfuscation.hpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <random>
 #include <array>
+#include <map>
+#include <chrono>
 
 namespace quicfuscate::stealth {
 


### PR DESCRIPTION
## Summary
- create `rust/` Cargo workspace with `core`, `crypto`, `fec` and `stealth` crates
- compile selected C++ sources with the `cc` crate to expose simple FFI
- add minimal Rust APIs wrapping the bindings
- patch missing includes in `XOR_Obfuscation.hpp`
- document building the Rust workspace in README

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_6861b6c0544083338bf76227f9b37321