### PR TITLE
Fix memory management in FEC module and add safer casts

### DIFF
--- a/fec/FEC_Modul.hpp
+++ b/fec/FEC_Modul.hpp
@@ -340,6 +340,7 @@ extern "C" {
     void fec_module_cleanup();
     int fec_module_encode(const uint8_t* data, size_t data_size, uint8_t** encoded_data, size_t* encoded_size);
     int fec_module_decode(const uint8_t* encoded_data, size_t encoded_size, uint8_t** decoded_data, size_t* decoded_size);
+    void fec_module_free_buffer(uint8_t* buffer);
     int fec_module_set_redundancy(double redundancy);
     int fec_module_get_statistics(void* stats_buffer, size_t buffer_size);
 }

--- a/tests/fec_module_test.cpp
+++ b/tests/fec_module_test.cpp
@@ -1,0 +1,20 @@
+#include "../fec/FEC_Modul.hpp"
+#include <cassert>
+int main() {
+    using namespace quicfuscate::stealth;
+    assert(fec_module_init() == 0);
+    const char msg[] = "hello";
+    uint8_t* enc = nullptr;
+    size_t enc_size = 0;
+    assert(fec_module_encode(reinterpret_cast<const uint8_t*>(msg), sizeof(msg), &enc, &enc_size) == 0);
+    uint8_t* dec = nullptr;
+    size_t dec_size = 0;
+    int res = fec_module_decode(enc, enc_size, &dec, &dec_size);
+    (void)res;
+    fec_module_free_buffer(enc);
+    if (res == 0) {
+        fec_module_free_buffer(dec);
+    }
+    fec_module_cleanup();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- replace `malloc` with `std::unique_ptr` inside `fec_module_encode`/`decode`
- add helper to free returned buffers
- provide stub for missing AVX512 routine
- introduce `sockaddr_to_endpoint` helper for safer address casts
- add simple unit test and run valgrind

## Testing
- `g++ -std=c++17 -mavx512f -mavx512bw -mavx512vl -mavx512dq -mbmi2 -O2 tests/fec_module_test.cpp fec/FEC_Modul.cpp -o tests/fec_module_test`
- `./tests/fec_module_test`
- `g++ -std=c++17 -mavx2 -O2 tests/fec_module_test.cpp fec/FEC_Modul.cpp -o tests/fec_module_test_valgrind`
- `valgrind ./tests/fec_module_test_valgrind`

------
https://chatgpt.com/codex/tasks/task_e_6861b6bb948c8333bae3bff3cda8c0f4