### PR TITLE
Remove manual buffer management from FEC API

### DIFF
--- a/fec/FEC_Modul.cpp
+++ b/fec/FEC_Modul.cpp
@@ -721,48 +721,33 @@ extern "C" {
         global_fec_module = nullptr;
     }
     
-    int fec_module_encode(const uint8_t* data, size_t data_size, uint8_t** encoded_data, size_t* encoded_size) {
-        if (!global_fec_module || !data || !encoded_data || !encoded_size) {
-            return -1;
+    std::vector<uint8_t> fec_module_encode(const uint8_t* data, size_t data_size) {
+        if (!global_fec_module || !data) {
+            return {};
         }
 
         try {
             std::vector<uint8_t> input(data, data + data_size);
-            auto result = global_fec_module->encode(input);
-
-            *encoded_size = result.size();
-            std::unique_ptr<uint8_t[]> buffer(new uint8_t[result.size()]);
-            std::memcpy(buffer.get(), result.data(), result.size());
-            *encoded_data = buffer.release();
-            return 0;
+            return global_fec_module->encode(input);
         } catch (...) {
-            return -1;
+            return {};
         }
     }
     
-    int fec_module_decode(const uint8_t* encoded_data, size_t encoded_size, uint8_t** decoded_data, size_t* decoded_size) {
-        if (!global_fec_module || !encoded_data || !decoded_data || !decoded_size) {
-            return -1;
+    std::vector<uint8_t> fec_module_decode(const uint8_t* encoded_data, size_t encoded_size) {
+        if (!global_fec_module || !encoded_data) {
+            return {};
         }
 
         try {
             std::vector<uint8_t> input(encoded_data, encoded_data + encoded_size);
             std::vector<std::vector<uint8_t>> shards = {input};
-            auto result = global_fec_module->decode(shards);
-
-            *decoded_size = result.size();
-            std::unique_ptr<uint8_t[]> buffer(new uint8_t[result.size()]);
-            std::memcpy(buffer.get(), result.data(), result.size());
-            *decoded_data = buffer.release();
-            return 0;
+            return global_fec_module->decode(shards);
         } catch (...) {
-            return -1;
+            return {};
         }
     }
 
-    void fec_module_free_buffer(uint8_t* buffer) {
-        delete[] buffer;
-    }
     
     int fec_module_set_redundancy(double redundancy) {
         if (!global_fec_module) {

--- a/fec/FEC_Modul.hpp
+++ b/fec/FEC_Modul.hpp
@@ -338,9 +338,8 @@ private:
 extern "C" {
     int fec_module_init();
     void fec_module_cleanup();
-    int fec_module_encode(const uint8_t* data, size_t data_size, uint8_t** encoded_data, size_t* encoded_size);
-    int fec_module_decode(const uint8_t* encoded_data, size_t encoded_size, uint8_t** decoded_data, size_t* decoded_size);
-    void fec_module_free_buffer(uint8_t* buffer);
+    std::vector<uint8_t> fec_module_encode(const uint8_t* data, size_t data_size);
+    std::vector<uint8_t> fec_module_decode(const uint8_t* encoded_data, size_t encoded_size);
     int fec_module_set_redundancy(double redundancy);
     int fec_module_get_statistics(void* stats_buffer, size_t buffer_size);
 }

--- a/tests/fec_module_test.cpp
+++ b/tests/fec_module_test.cpp
@@ -4,17 +4,10 @@ int main() {
     using namespace quicfuscate::stealth;
     assert(fec_module_init() == 0);
     const char msg[] = "hello";
-    uint8_t* enc = nullptr;
-    size_t enc_size = 0;
-    assert(fec_module_encode(reinterpret_cast<const uint8_t*>(msg), sizeof(msg), &enc, &enc_size) == 0);
-    uint8_t* dec = nullptr;
-    size_t dec_size = 0;
-    int res = fec_module_decode(enc, enc_size, &dec, &dec_size);
-    (void)res;
-    fec_module_free_buffer(enc);
-    if (res == 0) {
-        fec_module_free_buffer(dec);
-    }
+    auto enc = fec_module_encode(reinterpret_cast<const uint8_t*>(msg), sizeof(msg));
+    assert(!enc.empty());
+
+    auto dec = fec_module_decode(enc.data(), enc.size());
     fec_module_cleanup();
     return 0;
 }


### PR DESCRIPTION
## Summary
- return encoded/decoded data via `std::vector<uint8_t>`
- adjust C wrapper prototypes and implementation
- drop obsolete `fec_module_free_buffer`
- update test for new API and run under Valgrind to verify no leaks

## Testing
- `g++ -std=c++17 -mavx2 tests/fec_module_test.cpp fec/FEC_Modul.cpp -I fec -o tests/fec_module_test`
- `./tests/fec_module_test`
- `valgrind ./tests/fec_module_test`

------
https://chatgpt.com/codex/tasks/task_e_6861be2055808333a4e494bbad08638b