### PR TITLE
Add GoogleTest framework and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --target quicfuscate_tests -j
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,21 @@
 cmake_minimum_required(VERSION 3.15)
 project(QuicFuscate LANGUAGES CXX)
 
+include(CTest)
+option(BUILD_TESTING "Build tests" ON)
+
+include(FetchContent)
+if(BUILD_TESTING)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    )
+    FetchContent_MakeAvailable(googletest)
+    enable_testing()
+endif()
+
+find_package(OpenMP)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -109,4 +124,20 @@ target_link_libraries(quicfuscate_demo PRIVATE
     OpenSSL::Crypto
     quiche
 )
+
+if(BUILD_TESTING)
+    add_executable(quicfuscate_tests
+        tests/fec_module_test.cpp
+        fec/FEC_Modul.cpp
+        stealth/XOR_Obfuscation.cpp
+    )
+    target_compile_options(quicfuscate_tests PRIVATE -mavx2 -fopenmp)
+    target_link_libraries(quicfuscate_tests PRIVATE
+        gtest_main
+    )
+    if(OpenMP_CXX_FOUND)
+        target_link_libraries(quicfuscate_tests PRIVATE OpenMP::OpenMP_CXX)
+    endif()
+    add_test(NAME quicfuscate_tests COMMAND quicfuscate_tests)
+endif()
 

--- a/stealth/XOR_Obfuscation.hpp
+++ b/stealth/XOR_Obfuscation.hpp
@@ -7,6 +7,8 @@
 #include <memory>
 #include <random>
 #include <array>
+#include <chrono>
+#include <map>
 
 namespace quicfuscate::stealth {
 

--- a/tests/fec_module_test.cpp
+++ b/tests/fec_module_test.cpp
@@ -1,20 +1,45 @@
+#include <gtest/gtest.h>
 #include "../fec/FEC_Modul.hpp"
-#include <cassert>
-int main() {
-    using namespace quicfuscate::stealth;
-    assert(fec_module_init() == 0);
+#include "../stealth/XOR_Obfuscation.hpp"
+#include <numeric>
+
+using namespace quicfuscate::stealth;
+
+TEST(FECModule, EncodeDecode) {
+    ASSERT_EQ(fec_module_init(), 0);
     const char msg[] = "hello";
     uint8_t* enc = nullptr;
     size_t enc_size = 0;
-    assert(fec_module_encode(reinterpret_cast<const uint8_t*>(msg), sizeof(msg), &enc, &enc_size) == 0);
-    uint8_t* dec = nullptr;
-    size_t dec_size = 0;
-    int res = fec_module_decode(enc, enc_size, &dec, &dec_size);
-    (void)res;
+    ASSERT_EQ(fec_module_encode(reinterpret_cast<const uint8_t*>(msg), sizeof(msg), &enc, &enc_size), 0);
+    EXPECT_GT(enc_size, 0u);
     fec_module_free_buffer(enc);
-    if (res == 0) {
-        fec_module_free_buffer(dec);
-    }
     fec_module_cleanup();
-    return 0;
+}
+
+TEST(Crypto, DeriveKeyDeterministic) {
+    std::vector<uint8_t> salt = {0,1,2,3};
+    auto k1 = xor_utils::derive_key_pbkdf2("password", salt, 5, 16);
+    auto k2 = xor_utils::derive_key_pbkdf2("password", salt, 5, 16);
+    EXPECT_EQ(k1, k2);
+    EXPECT_EQ(k1.size(), 16u);
+}
+
+TEST(Crypto, EntropyCalculation) {
+    std::vector<uint8_t> data(256);
+    std::iota(data.begin(), data.end(), 0);
+    double entropy = xor_utils::calculate_entropy(data);
+    EXPECT_NEAR(entropy, 8.0, 0.01);
+}
+
+TEST(Stealth, XORObfuscatorRoundTrip) {
+    XORObfuscator obf;
+    std::vector<uint8_t> msg{'h','e','l','l','o'};
+    auto enc = obf.obfuscate(msg, XORPattern::SIMPLE, 42);
+    auto dec = obf.deobfuscate(enc, XORPattern::SIMPLE, 42);
+    EXPECT_EQ(dec, msg);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
## Summary
- add GoogleTest via FetchContent
- add OpenMP detection and compile options for test target
- port fec module test to GoogleTest and add crypto & stealth tests
- add CTest target and GitHub Actions workflow

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target quicfuscate_tests -j`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6861be23f4a483338d5be1d389f8d798