### PR TITLE
Introduce shared QUIC constants

### DIFF
--- a/core/quic_connection.hpp
+++ b/core/quic_connection.hpp
@@ -2,6 +2,7 @@
 #define QUIC_CONNECTION_HPP
 
 #include "quic_core_types.hpp"
+#include "quic_constants.hpp"
 #include "../optimize/unified_optimizations.hpp"    // Für alle Optimierungen (inkl. ZeroRttConfig)
 #include <boost/asio.hpp>
 #include <boost/asio/ip/udp.hpp>  // für UDP-Socket
@@ -440,7 +441,7 @@ private:
     BrowserFingerprint browser_fingerprint_{BrowserFingerprint::CHROME_LATEST}; // Aktueller Browser-Fingerprint
     
     // Puffer und Datenübertragung
-    std::array<uint8_t, 1500> recv_buffer_;     // Puffer für eingehende UDP-Pakete
+    std::array<uint8_t, DEFAULT_MAX_MTU> recv_buffer_; // Puffer für eingehende UDP-Pakete
     std::array<uint8_t, 2048> send_buf_;        // Puffer für ausgehende QUIC-Pakete
     mutable std::mutex socket_mutex_;           // Mutex für Thread-sichere Socket-Operationen
     
@@ -549,9 +550,9 @@ private:
     std::vector<std::string> available_interfaces_;     // Liste verfügbarer Netzwerkschnittstellen
     std::vector<boost::asio::ip::udp::endpoint> previous_endpoints_; // Liste früherer Endpunkte für Migration
     boost::asio::ip::udp::endpoint original_endpoint_;  // Ursprünglicher Endpunkt (für Zurückwechseln)
-    uint64_t path_challenge_timeout_ms_{500};           // Timeout für Path Challenge in Millisekunden
-    uint64_t max_migration_attempts_{5};                // Maximale Anzahl von Migrationsversuchen
-    uint64_t migration_cooldown_ms_{1000};              // Abkühlungszeit zwischen Migrationsversuchen
+    uint64_t path_challenge_timeout_ms_{DEFAULT_PATH_CHALLENGE_TIMEOUT_MS}; // Timeout für Path Challenge in Millisekunden
+    uint64_t max_migration_attempts_{DEFAULT_MAX_MIGRATION_ATTEMPTS}; // Maximale Anzahl von Migrationsversuchen
+    uint64_t migration_cooldown_ms_{DEFAULT_MIGRATION_COOLDOWN_MS}; // Abkühlungszeit zwischen Migrationsversuchen
     std::function<void(bool, const std::string&, const std::string&)> migration_callback_; // Benachrichtigungsfunktion
     
     // Private Migration-Methoden
@@ -566,16 +567,16 @@ private:
     
     // MTU Discovery bezogene private Variablen und Methoden
     bool mtu_discovery_enabled_{false};                // Flag, ob MTU Discovery aktiviert ist
-    uint16_t current_mtu_{1350};                       // Aktuelle MTU-Größe
-    uint16_t min_mtu_{1200};                           // Minimale MTU (RFC 8899 empfiehlt 1200 als Minimum)
-    uint16_t max_mtu_{1500};                           // Maximale MTU (typische Ethernet MTU)
-    uint16_t mtu_step_size_{10};                       // Schrittgröße für MTU-Probing
-    uint16_t target_mtu_{1500};                        // Ziel-MTU
-    uint16_t last_successful_mtu_{1350};               // Zuletzt erfolgreich verwendete MTU
+    uint16_t current_mtu_{DEFAULT_INITIAL_MTU};        // Aktuelle MTU-Größe
+    uint16_t min_mtu_{DEFAULT_MIN_MTU};                // Minimale MTU (RFC 8899 empfiehlt 1200 als Minimum)
+    uint16_t max_mtu_{DEFAULT_MAX_MTU};                // Maximale MTU (typische Ethernet MTU)
+    uint16_t mtu_step_size_{DEFAULT_MTU_STEP_SIZE};    // Schrittgröße für MTU-Probing
+    uint16_t target_mtu_{DEFAULT_MAX_MTU};             // Ziel-MTU
+    uint16_t last_successful_mtu_{DEFAULT_INITIAL_MTU}; // Zuletzt erfolgreich verwendete MTU
     uint16_t current_probe_mtu_{0};                    // Aktuell getestete MTU
     std::chrono::steady_clock::time_point last_probe_time_; // Zeitpunkt des letzten MTU-Probes
-    uint32_t probe_timeout_ms_{1000};                  // Timeout für MTU-Probes in Millisekunden
-    uint16_t blackhole_detection_threshold_{2};         // Schwellenwert für Blackhole-Erkennung
+    uint32_t probe_timeout_ms_{DEFAULT_MTU_PROBE_TIMEOUT_MS}; // Timeout für MTU-Probes in Millisekunden
+    uint16_t blackhole_detection_threshold_{DEFAULT_BLACKHOLE_DETECTION_THRESHOLD}; // Schwellenwert für Blackhole-Erkennung
     uint16_t consecutive_failures_{0};                 // Zähler für aufeinanderfolgende Fehlschläge
     bool in_search_phase_{false};                      // Flag, ob aktuell im Suchprozess
     bool mtu_validated_{false};                        // Flag, ob aktuelle MTU validiert ist

--- a/core/quic_connection_impl.cpp
+++ b/core/quic_connection_impl.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "quic_connection.hpp"
+#include "quic_constants.hpp"
 #include "../optimize/unified_optimizations.hpp"
 #include <iostream>
 #include <chrono>
@@ -420,7 +421,7 @@ void QuicConnection::send_pending_packets() {
         return;
     }
     
-    static uint8_t out[1350]; // Standard MTU size buffer
+    static uint8_t out[DEFAULT_INITIAL_MTU]; // Standard MTU size buffer
     
     while (true) {
         ssize_t written = quiche_conn_send(quiche_conn_, out, sizeof(out));

--- a/core/quic_constants.hpp
+++ b/core/quic_constants.hpp
@@ -1,0 +1,82 @@
+#ifndef QUIC_CONSTANTS_HPP
+#define QUIC_CONSTANTS_HPP
+
+#include <cstdint>
+#include <cstddef>
+
+namespace quicfuscate {
+
+// RFC 8899 recommends a minimum datagram payload of 1200 bytes to
+// avoid IPv6 fragmentation and ensure interoperability across paths.
+inline constexpr uint16_t DEFAULT_MIN_MTU = 1200;
+
+// Typical Ethernet MTU used as an upper bound for probing.
+inline constexpr uint16_t DEFAULT_MAX_MTU = 1500;
+
+// Common starting MTU for QUIC before the path has been validated.
+inline constexpr uint16_t DEFAULT_INITIAL_MTU = 1350;
+
+// Increment used when probing for a larger MTU.
+inline constexpr uint16_t DEFAULT_MTU_STEP_SIZE = 10;
+
+// Maximum datagram size to bundle without exceeding DEFAULT_MIN_MTU.
+inline constexpr size_t DEFAULT_MAX_BUNDLE_SIZE = DEFAULT_MIN_MTU;
+
+// Maximum fragment size for DPI evasion kept at the minimum MTU.
+inline constexpr size_t DEFAULT_MAX_FRAGMENT_SIZE = DEFAULT_MIN_MTU;
+
+// Timeout waiting for a PATH_CHALLENGE response during migration (ms).
+inline constexpr uint64_t DEFAULT_PATH_CHALLENGE_TIMEOUT_MS = 500;
+
+// Maximum allowed migration attempts before giving up.
+inline constexpr uint64_t DEFAULT_MAX_MIGRATION_ATTEMPTS = 5;
+
+// Cooldown period between migration attempts (ms).
+inline constexpr uint64_t DEFAULT_MIGRATION_COOLDOWN_MS = 1000;
+
+// Timeout waiting for MTU probe acknowledgements (ms).
+inline constexpr uint32_t DEFAULT_MTU_PROBE_TIMEOUT_MS = 1000;
+
+// Number of consecutive probe failures before assuming a black hole.
+inline constexpr uint16_t DEFAULT_BLACKHOLE_DETECTION_THRESHOLD = 2;
+// Alternative threshold used by the path MTU manager.
+inline constexpr uint8_t DEFAULT_PATH_BLACKHOLE_THRESHOLD = 3;
+
+// Interval for adaptive MTU checks based on network feedback (ms).
+inline constexpr uint32_t DEFAULT_ADAPTIVE_CHECK_INTERVAL_MS = 10000;
+
+// Periodic probe interval after MTU was validated (ms).
+inline constexpr uint32_t DEFAULT_PERIODIC_PROBE_INTERVAL_MS = 60000;
+
+// Expiry for outstanding probes when no response is seen (ms).
+inline constexpr uint32_t DEFAULT_PROBE_TIMEOUT_MS = 2000;
+
+// Minimum bandwidth considered acceptable for a migration path (kbps).
+inline constexpr uint32_t DEFAULT_MIN_BANDWIDTH_THRESHOLD_KBPS = 1000;
+
+// Maximum RTT considered acceptable when evaluating paths (ms).
+inline constexpr uint32_t DEFAULT_MAX_RTT_THRESHOLD_MS = 200;
+
+// Maximum delay inserted for timing randomization (microseconds).
+inline constexpr uint32_t DEFAULT_DPI_MAX_DELAY_US = 5000;
+
+// Minimum delay inserted for timing randomization (microseconds).
+inline constexpr uint32_t DEFAULT_DPI_MIN_DELAY_US = 100;
+
+// Maximum time a migration event may be delayed to appear natural (ms).
+inline constexpr uint32_t DEFAULT_MAX_MIGRATION_DELAY_MS = 2000;
+// Minimum delay used when randomizing migration timing (ms).
+inline constexpr uint32_t DEFAULT_MIN_MIGRATION_DELAY_MS = 100;
+
+// Default cap on cached sessions used for 0-RTT handshakes.
+inline constexpr size_t DEFAULT_MAX_CACHED_SESSIONS = 1000;
+
+// Default maximum number of concurrent streams allowed.
+inline constexpr size_t DEFAULT_MAX_CONCURRENT_STREAMS = 1000;
+
+// Default number of iterations for PBKDF2 operations.
+inline constexpr size_t DEFAULT_PBKDF2_ITERATIONS = 10000;
+
+} // namespace quicfuscate
+
+#endif // QUIC_CONSTANTS_HPP

--- a/core/quic_path_mtu_manager.hpp
+++ b/core/quic_path_mtu_manager.hpp
@@ -10,6 +10,7 @@
  */
 
 #include "error_handling.hpp"
+#include "quic_constants.hpp"
 #include <chrono>
 #include <iostream>
 #include <algorithm>
@@ -62,11 +63,11 @@ public:
      * @param step_size Schrittgröße für MTU-Proben (Standard: 10 Bytes)
      * @param blackhole_threshold Schwellenwert für Blackhole-Erkennung (Standard: 3)
      */
-    PathMtuManager(QuicConnection& connection, 
-                  uint16_t min_mtu = 1200, 
-                  uint16_t max_mtu = 1500, 
-                  uint16_t step_size = 10,
-                  uint8_t blackhole_threshold = 3);
+    PathMtuManager(QuicConnection& connection,
+                  uint16_t min_mtu = DEFAULT_MIN_MTU,
+                  uint16_t max_mtu = DEFAULT_MAX_MTU,
+                  uint16_t step_size = DEFAULT_MTU_STEP_SIZE,
+                  uint8_t blackhole_threshold = DEFAULT_PATH_BLACKHOLE_THRESHOLD);
     
     /**
      * @brief Destruktor
@@ -213,14 +214,14 @@ private:
     std::function<void(const MtuChange&)> mtu_change_callback_; // Callback für MTU-Änderungen
     
     // Häufigkeit der MTU-Anpassung basierend auf Netzwerkbedingungen
-    std::chrono::milliseconds adaptive_check_interval_{10000}; // 10 Sekunden
+    std::chrono::milliseconds adaptive_check_interval_{DEFAULT_ADAPTIVE_CHECK_INTERVAL_MS}; // 10 Sekunden
     std::chrono::steady_clock::time_point last_adaptive_check_; // Letzter Check
     
     // Häufigkeit der periodischen Probes nach erfolgreicher Validierung
-    std::chrono::milliseconds periodic_probe_interval_{60000}; // 1 Minute
+    std::chrono::milliseconds periodic_probe_interval_{DEFAULT_PERIODIC_PROBE_INTERVAL_MS}; // 1 Minute
     
     // Timeout für ausstehende Proben
-    std::chrono::milliseconds probe_timeout_{2000}; // 2 Sekunden
+    std::chrono::milliseconds probe_timeout_{DEFAULT_PROBE_TIMEOUT_MS}; // 2 Sekunden
     
     // Private Hilfsmethoden
     

--- a/stealth/QuicFuscate_Stealth.hpp
+++ b/stealth/QuicFuscate_Stealth.hpp
@@ -35,6 +35,7 @@
 #include <cmath>
 
 #include "../core/quic_core_types.hpp"
+#include "../core/quic_constants.hpp"
 #include "stealth_gov.hpp"
 #include "uTLS.hpp"
 
@@ -163,7 +164,7 @@ struct QPACKConfig {
 
 struct ZeroRTTConfig {
     bool enable_zero_rtt = true;
-    size_t max_cached_sessions = 1000;
+    size_t max_cached_sessions = DEFAULT_MAX_CACHED_SESSIONS;
     std::chrono::hours session_timeout{24};
     bool enable_session_tickets = true;
     bool enable_psk = true;
@@ -172,14 +173,14 @@ struct ZeroRTTConfig {
 
 struct DatagramConfig {
     bool enable_bundling = true;
-    size_t max_bundle_size = 1200;
+    size_t max_bundle_size = DEFAULT_MAX_BUNDLE_SIZE;
     std::chrono::milliseconds bundle_timeout{10};
     bool enable_compression = true;
     uint8_t default_priority = 128;
 };
 
 struct StreamConfig {
-    size_t max_concurrent_streams = 1000;
+    size_t max_concurrent_streams = DEFAULT_MAX_CONCURRENT_STREAMS;
     size_t stream_buffer_size = 65536;
     bool enable_multiplexing = true;
     bool enable_flow_control = true;

--- a/stealth/stealth_gov.hpp
+++ b/stealth/stealth_gov.hpp
@@ -10,6 +10,7 @@
 #include "browser_profiles/tls_profiles/uTLS_fingerprints.hpp"
 #include "browser_profiles/headers/FakeHeaders.hpp"
 #include "DoH.hpp"
+#include "../core/quic_constants.hpp"
 // QUIC Path Migration definitions are now included directly in this file
 
 #include <memory>
@@ -126,7 +127,7 @@ struct XORConfig {
     size_t max_key_cache_size = 1024;
     bool enable_key_derivation = true;
     std::string key_derivation_salt = "QuicFuscateStealth2024";
-    size_t pbkdf2_iterations = 10000;
+    size_t pbkdf2_iterations = DEFAULT_PBKDF2_ITERATIONS;
     
     // Performance-Tuning
     size_t simd_chunk_size = 64;
@@ -211,12 +212,12 @@ struct DPIEvasionConfig {
     
     // Paketfragmentierung
     size_t min_fragment_size = 64;
-    size_t max_fragment_size = 1200;
+    size_t max_fragment_size = DEFAULT_MAX_FRAGMENT_SIZE;
     double fragmentation_probability = 0.3;
     
     // Timing-Randomisierung
-    std::chrono::microseconds min_delay{100};
-    std::chrono::microseconds max_delay{5000};
+    std::chrono::microseconds min_delay{DEFAULT_DPI_MIN_DELAY_US};
+    std::chrono::microseconds max_delay{DEFAULT_DPI_MAX_DELAY_US};
     double timing_randomization_probability = 0.5;
     
     // Payload-Randomisierung
@@ -313,9 +314,9 @@ struct PathMigrationConfig {
     PathMigrationStrategy strategy = PathMigrationStrategy::NONE;
     
     // Quality Thresholds
-    uint32_t max_rtt_threshold_ms = 200;
+    uint32_t max_rtt_threshold_ms = DEFAULT_MAX_RTT_THRESHOLD_MS;
     double max_loss_rate_threshold = 0.05;
-    uint32_t min_bandwidth_threshold_kbps = 1000;
+    uint32_t min_bandwidth_threshold_kbps = DEFAULT_MIN_BANDWIDTH_THRESHOLD_KBPS;
     
     // Migration Behavior
     bool auto_migrate = true;
@@ -329,8 +330,8 @@ struct PathMigrationConfig {
     
     // Stealth Features
     bool randomize_migration_timing = true;
-    std::chrono::milliseconds min_migration_delay{100};
-    std::chrono::milliseconds max_migration_delay{2000};
+    std::chrono::milliseconds min_migration_delay{DEFAULT_MIN_MIGRATION_DELAY_MS};
+    std::chrono::milliseconds max_migration_delay{DEFAULT_MAX_MIGRATION_DELAY_MS};
     bool obfuscate_path_probes = true;
 };
 


### PR DESCRIPTION
## Summary
- add `quic_constants.hpp` for reusable connection constants
- refactor core and stealth modules to use the new constants
- document rationale for each constant

## Testing
- `cmake ..` *(fails: Imported target "quiche" includes non-existent path)*

------
https://chatgpt.com/codex/tasks/task_e_6861be2761c48333b2a40e009b2e20e4