### PR TITLE
Improve build docs and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build quiche
+        run: |
+          cd libs/quiche-patched
+          cargo build --release
+      - name: Configure
+        run: |
+          mkdir build && cd build
+          cmake ..
+      - name: Build
+        run: |
+          cd build
+          cmake --build .
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,3 +110,8 @@ target_link_libraries(quicfuscate_demo PRIVATE
     quiche
 )
 
+enable_testing()
+add_executable(fec_module_test tests/fec_module_test.cpp)
+target_link_libraries(fec_module_test PRIVATE quicfuscate_fec)
+add_test(NAME fec_module_test COMMAND fec_module_test)
+

--- a/README.md
+++ b/README.md
@@ -84,16 +84,15 @@ This repository uses a Git submodule to include a patched QUIC library.
 After cloning the project, initialize the submodule with:
 
 ```bash
-git submodule update --init libs/quiche-patched
+git submodule update --init --recursive libs/quiche-patched
 ```
 
 If the fetch fails, verify that the URL in `.gitmodules` points to a
 repository that hosts the required commit.
 
-### Building with CMake
+### Building quiche
 
-After initializing the submodule you need to compile the patched **quiche**
-library using Cargo:
+Compile the patched **quiche** library using Cargo:
 
 ```bash
 cd libs/quiche-patched
@@ -101,16 +100,60 @@ cargo build --release
 cd ../..
 ```
 
-With the library built you can generate the project with CMake:
+### Building with CMake
+
+Generate the project and build all binaries:
 
 ```bash
 mkdir build && cd build
 cmake ..
-make
+cmake --build .
 ```
 
-All binaries will be placed inside the `build/` directory.
+### Running the tests
 
+After building, execute the unit tests with CTest:
+
+```bash
+cd build
+ctest --output-on-failure
+```
+
+## 🖥️ Command-Line Usage
+
+The project provides several binaries once built:
+
+- **quicfuscate_demo** – feature-rich demo tool with many options.
+- **quicfuscate_client** – minimal client accepting `<host> <port>` arguments.
+- **quicfuscate_server** – placeholder server without arguments.
+
+Run `quicfuscate_demo --help` to see all available options. Important flags include:
+
+```
+  -s, --server <host>        Server hostname (default: example.com)
+  -p, --port <port>          Server port (default: 443)
+  -f, --fingerprint <name>   Browser fingerprint (chrome, firefox, safari, ...)
+      --no-utls              Disable uTLS and use regular TLS
+      --verify-peer          Enable certificate validation
+      --ca-file <path>       CA file for peer verification
+  -v, --verbose              Verbose logging
+      --debug-tls            Show TLS debug information
+      --list-fingerprints    List available browser fingerprints
+```
+
+## 🔄 Continuous Integration
+
+The repository includes a GitHub Actions workflow that builds the project and
+runs the tests on every push or pull request. You can find the workflow in
+`.github/workflows/ci.yml`. To reproduce the CI steps locally run:
+
+```bash
+git submodule update --init --recursive
+cd libs/quiche-patched && cargo build --release && cd ../..
+mkdir -p build && cd build
+cmake .. && cmake --build .
+ctest --output-on-failure
+```
 
 ## 📜 License
 


### PR DESCRIPTION
## Summary
- update build instructions with submodules, cargo, CMake and ctest
- document demo/client/server CLI options
- add section on CI workflow and running tests locally
- add CI workflow file
- enable tests in CMake

## Testing
- `git submodule update --init --recursive` *(fails: not our ref)*
- `cargo build --release` in `libs/quiche-patched` *(fails: could not find `Cargo.toml`)*
- `cmake ..` *(fails: non-existent path `libs/quiche-patched/include`)*
- `ctest --output-on-failure` *(fails: test not run)*

------
https://chatgpt.com/codex/tasks/task_e_6861be2b8d1c8333b5a0743032cf1368