### PR TITLE
Build quiche via Cargo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,24 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenSSL REQUIRED)
 
-add_library(quiche STATIC IMPORTED)
+# Build the patched quiche library with Cargo
+set(QUICHE_LIB "${PROJECT_SOURCE_DIR}/libs/quiche-patched/target/release/libquiche.a")
+
+add_custom_command(
+    OUTPUT ${QUICHE_LIB}
+    COMMAND cargo build --release
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/libs/quiche-patched
+    COMMENT "Building quiche via cargo"
+)
+
+add_custom_target(quiche_build ALL DEPENDS ${QUICHE_LIB})
+
+add_library(quiche STATIC IMPORTED GLOBAL)
 set_target_properties(quiche PROPERTIES
-    IMPORTED_LOCATION "${PROJECT_SOURCE_DIR}/libs/quiche-patched/target/release/libquiche.a"
+    IMPORTED_LOCATION "${QUICHE_LIB}"
     INTERFACE_INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/libs/quiche-patched/include"
 )
+add_dependencies(quiche quiche_build)
 
 add_library(quicfuscate_core
     core/quic_connection_impl.cpp
@@ -34,6 +47,7 @@ target_link_libraries(quicfuscate_core
         OpenSSL::SSL
         OpenSSL::Crypto
 )
+add_dependencies(quicfuscate_core quiche_build)
 
 add_library(quicfuscate_crypto
     crypto/aegis128l.cpp

--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ cd build
 ctest --output-on-failure
 ```
 
+## 👷 Developer Notes
+
+The CMake build expects the patched **quiche** sources under
+`libs/quiche-patched` to be compiled with Cargo. When configuring the project
+manually run:
+
+```bash
+git submodule update --init --recursive libs/quiche-patched
+cd libs/quiche-patched && cargo build --release && cd ../..
+mkdir -p build && cd build
+cmake .. && cmake --build .
+```
+
+
 ## 🖥️ Command-Line Usage
 
 The project provides several binaries once built:


### PR DESCRIPTION
## Summary
- add custom target to CMakeLists to build quiche with Cargo
- ensure quiche is built before quicfuscate targets
- document the manual build steps in a developer note

## Testing
- `cmake ..` *(fails: quiche sources missing)*
- `make` *(fails: could not find Cargo.toml)*
- `ctest --output-on-failure` *(fails: test binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68623b4329948333a359d8acf1b2b087