### PR TITLE
Set up Rust workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ cmake .. && cmake --build .
 
 Additional Rust code resides under the `rust/` directory. It currently
 contains an empty `core` crate serving as the foundation for the upcoming
-Rust reimplementation. Build all crates with:
+Rust reimplementation. The workspace root `rust/Cargo.toml` opts into the
+edition 2021 resolver and is built as part of the CI pipeline. Build all
+crates locally with:
 
 ```bash
 cd rust

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
+resolver = "2"
 members = ["core"]


### PR DESCRIPTION
## Summary
- clarify README's instructions for the Rust workspace
- explicitly set resolver version in the workspace `Cargo.toml`

## Testing
- `cargo build --manifest-path rust/Cargo.toml --workspace`
- `cmake .. && cmake --build .` *(fails: target specific option mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68625714a9088333b71ddf812399dbf3