### PR TITLE
Add helper script for quiche submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ git submodule set-url libs/quiche-patched <mirror-url>
 git submodule update --init libs/quiche-patched
 ```
 
+Alternatively, run the helper script to automatically fetch the
+submodule and build it in one step (optionally pass a mirror URL):
+
+```bash
+./scripts/fetch_quiche.sh [mirror-url]
+```
+
 ### Building quiche
 
 Compile the patched **quiche** library using Cargo:

--- a/scripts/fetch_quiche.sh
+++ b/scripts/fetch_quiche.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+MIRROR_URL=${1:-https://github.com/cloudflare/quiche.git}
+SUBMODULE_PATH="libs/quiche-patched"
+
+# Update submodule URL to provided mirror
+if [ ! -d "$SUBMODULE_PATH" ]; then
+    mkdir -p "$SUBMODULE_PATH"
+fi
+git submodule set-url "$SUBMODULE_PATH" "$MIRROR_URL"
+
+echo "Fetching quiche from $MIRROR_URL ..."
+
+git submodule update --init "$SUBMODULE_PATH"
+
+# Build the patched quiche library
+( cd "$SUBMODULE_PATH" && cargo build --release )


### PR DESCRIPTION
## Summary
- document fetching `libs/quiche-patched` via helper script in README
- add `scripts/fetch_quiche.sh` to download and build the patched quiche
- revert submodule pointer to the pinned commit

## Testing
- `cargo build --release` in `rust/` workspace
- `git submodule update --init libs/quiche-patched` fails because the pinned commit is not in upstream, which matches README instructions


------
https://chatgpt.com/codex/tasks/task_e_686286eae4e8833396600fbf71057f20