### PR TITLE
Improve submodule instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,13 @@ After cloning the project, initialize the submodule with:
 git submodule update --init --recursive libs/quiche-patched
 ```
 
-If the command fails with a missing commit error, the upstream
-`quiche` repository might not contain the pinned revision
-`5700a7c74927d2c4912ac95e904c6ad3642b6868`. In that case, update the
+If the command fails with a missing commit error (e.g.
+```
+fatal: remote error: upload-pack: not our ref 5700a7c74927d2c4912ac95e904c6ad3642b6868
+Fetched in submodule path 'libs/quiche-patched', but it did not contain 5700a7c74927d2c4912ac95e904c6ad3642b6868.
+```
+), the upstream `quiche` repository might not contain the pinned
+revision `5700a7c74927d2c4912ac95e904c6ad3642b6868`. Update the
 submodule URL to a mirror that includes this commit and retry:
 
 ```bash
@@ -100,8 +104,9 @@ git submodule set-url libs/quiche-patched <mirror-url>
 git submodule update --init libs/quiche-patched
 ```
 
-Alternatively, run the helper script to automatically fetch the
-submodule and build it in one step (optionally pass a mirror URL):
+Alternatively, run the helper script to automatically set the mirror,
+fetch the sources and build the library in one step (optionally pass a
+mirror URL):
 
 ```bash
 ./scripts/fetch_quiche.sh [mirror-url]

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -2312,6 +2312,36 @@ int main() {
 ### Libraries
 - `libs/quiche-patched/`: Modified QUIC implementation from Google
 
+#### Fetching `libs/quiche-patched`
+The directory is left empty in the repository. Initialize the submodule
+after cloning:
+
+```bash
+git submodule update --init --recursive libs/quiche-patched
+```
+
+If you encounter an error like:
+
+```
+fatal: remote error: upload-pack: not our ref 5700a7c74927d2c4912ac95e904c6ad3642b6868
+Fetched in submodule path 'libs/quiche-patched', but it did not contain 5700a7c74927d2c4912ac95e904c6ad3642b6868.
+```
+
+the upstream repository lacks the pinned revision. Set the submodule URL
+to a mirror that contains the commit and fetch again:
+
+```bash
+git submodule set-url libs/quiche-patched <mirror-url>
+git submodule update --init libs/quiche-patched
+```
+
+Alternatively, run the helper script from the repository root, which
+automatically updates the URL and builds the library:
+
+```bash
+./scripts/fetch_quiche.sh [mirror-url]
+```
+
 ## Verification
 This documentation has been verified to cover all files in the QuicFuscate project:
 


### PR DESCRIPTION
## Summary
- document the exact error when `libs/quiche-patched` fails to fetch
- mention the helper script builds the library after fetching
- add a detailed section in `DOCUMENTATION.md` about fetching `libs/quiche-patched`

## Testing
- `cargo check --manifest-path rust/Cargo.toml`
- `cmake --build .` *(fails: target specific option mismatch)*
- `ctest --output-on-failure` *(fails: test executables missing)*
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686315524304833383957575b0759a3b