### PR TITLE
Add Rust stubs for crypto, fec and stealth

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,8 @@
 [workspace]
 resolver = "2"
-members = ["core"]
+members = [
+    "core",
+    "crypto",
+    "fec",
+    "stealth",
+]

--- a/rust/crypto/Cargo.toml
+++ b/rust/crypto/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "crypto"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]

--- a/rust/crypto/src/lib.rs
+++ b/rust/crypto/src/lib.rs
@@ -1,0 +1,82 @@
+pub struct AEGIS128X;
+impl AEGIS128X {
+    pub fn new() -> Self { Self }
+}
+
+pub struct AEGIS128L;
+impl AEGIS128L {
+    pub fn new() -> Self { Self }
+}
+
+pub struct MORUS1280;
+impl MORUS1280 {
+    pub fn new() -> Self { Self }
+}
+
+#[derive(Clone, Copy)]
+pub enum CipherSuite {
+    Aegis128xVaes512,
+    Aegis128xAesni,
+    Aegis128lNeon,
+    Aegis128lAesni,
+    Morus1280_128,
+}
+
+pub struct CipherSuiteSelector {
+    suite: CipherSuite,
+}
+
+impl CipherSuiteSelector {
+    pub fn new() -> Self {
+        Self { suite: CipherSuite::Aegis128xVaes512 }
+    }
+
+    pub fn select_best_cipher_suite(&self) -> CipherSuite {
+        self.suite
+    }
+
+    pub fn set_cipher_suite(&mut self, suite: CipherSuite) {
+        self.suite = suite;
+    }
+
+    pub fn encrypt(
+        &self,
+        _plaintext: &[u8],
+        _key: &[u8],
+        _nonce: &[u8],
+        _ad: &[u8],
+        _ciphertext: &mut Vec<u8>,
+        _tag: &mut [u8],
+    ) {
+    }
+
+    pub fn decrypt(
+        &self,
+        _ciphertext: &[u8],
+        _key: &[u8],
+        _nonce: &[u8],
+        _ad: &[u8],
+        _tag: &[u8],
+        _plaintext: &mut Vec<u8>,
+    ) -> bool {
+        true
+    }
+
+    pub fn get_current_cipher_suite(&self) -> CipherSuite {
+        self.suite
+    }
+
+    pub fn get_cipher_suite_name(&self) -> &'static str {
+        "stub"
+    }
+
+    pub fn is_hardware_accelerated(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn placeholder() {}
+}

--- a/rust/fec/Cargo.toml
+++ b/rust/fec/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "fec"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]

--- a/rust/fec/src/lib.rs
+++ b/rust/fec/src/lib.rs
@@ -1,0 +1,27 @@
+pub struct FECConfig;
+
+pub struct FECPacket;
+
+pub struct NetworkMetrics;
+
+pub struct FECModule;
+
+impl FECModule {
+    pub fn new(_config: FECConfig) -> Self { Self }
+
+    pub fn encode_packet(&self, _data: &[u8]) -> Vec<FECPacket> {
+        Vec::new()
+    }
+
+    pub fn decode(&self, _packets: &[FECPacket]) -> Vec<u8> {
+        Vec::new()
+    }
+
+    pub fn update_network_metrics(&self, _metrics: NetworkMetrics) {}
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn placeholder() {}
+}

--- a/rust/stealth/Cargo.toml
+++ b/rust/stealth/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "stealth"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -1,0 +1,15 @@
+pub struct QuicFuscateStealth;
+
+impl QuicFuscateStealth {
+    pub fn new() -> Self { Self }
+
+    pub fn initialize(&self) -> bool { true }
+
+    pub fn shutdown(&self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn placeholder() {}
+}


### PR DESCRIPTION
## Summary
- create new Rust crates `crypto`, `fec`, and `stealth`
- stub minimal public APIs matching the C++ modules
- update workspace members
- add placeholder unit tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68632228ac2083339feb879540a7612b