### PR TITLE
Add stub tests for core and stealth components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,3 +164,14 @@ add_executable(path_mtu_manager_test tests/path_mtu_manager_test.cpp)
 target_link_libraries(path_mtu_manager_test PRIVATE gtest_main)
 add_test(NAME path_mtu_manager_test COMMAND path_mtu_manager_test)
 
+add_executable(quic_connection_test tests/quic_connection_test.cpp)
+target_link_libraries(quic_connection_test PRIVATE gtest_main)
+add_test(NAME quic_connection_test COMMAND quic_connection_test)
+
+add_executable(xor_obfuscation_test tests/xor_obfuscation_test.cpp)
+target_link_libraries(xor_obfuscation_test PRIVATE quicfuscate_stealth gtest_main)
+add_test(NAME xor_obfuscation_test COMMAND xor_obfuscation_test)
+
+add_executable(path_mtu_probe_logic_test tests/path_mtu_probe_logic_test.cpp)
+target_link_libraries(path_mtu_probe_logic_test PRIVATE gtest_main)
+add_test(NAME path_mtu_probe_logic_test COMMAND path_mtu_probe_logic_test)

--- a/tests/path_mtu_probe_logic_test.cpp
+++ b/tests/path_mtu_probe_logic_test.cpp
@@ -1,0 +1,11 @@
+#include "../core/quic_path_mtu_manager.hpp"
+#include <gtest/gtest.h>
+#include <type_traits>
+
+using namespace quicfuscate;
+
+TEST(PathMtuManagerTest, HasProbeMethods) {
+    static_assert(std::is_member_function_pointer_v<decltype(&PathMtuManager::send_probe)>);
+    static_assert(std::is_member_function_pointer_v<decltype(&PathMtuManager::handle_probe_response)>);
+    SUCCEED();
+}

--- a/tests/quic_connection_test.cpp
+++ b/tests/quic_connection_test.cpp
@@ -1,0 +1,11 @@
+#include "../core/quic_connection.hpp"
+#include <gtest/gtest.h>
+#include <type_traits>
+
+using namespace quicfuscate;
+
+TEST(QuicConnectionTest, Constructible) {
+    static_assert(std::is_constructible_v<QuicConnection, boost::asio::io_context&, const QuicConfig&>,
+                  "QuicConnection should be constructible with io_context and QuicConfig");
+    SUCCEED();
+}

--- a/tests/xor_obfuscation_test.cpp
+++ b/tests/xor_obfuscation_test.cpp
@@ -1,0 +1,14 @@
+#include "../stealth/XOR_Obfuscation.hpp"
+#include <gtest/gtest.h>
+#include <vector>
+
+using namespace quicfuscate::stealth;
+
+TEST(XORObfuscationTest, EncodeDecodeRoundtrip) {
+    XORObfuscator obf;
+    std::vector<uint8_t> data{1,2,3,4,5};
+    auto encoded = obf.obfuscate(data, XORPattern::SIMPLE, 42);
+    EXPECT_EQ(encoded.size(), data.size());
+    auto decoded = obf.deobfuscate(encoded, XORPattern::SIMPLE, 42);
+    EXPECT_EQ(decoded, data);
+}


### PR DESCRIPTION
## Summary
- create compile-time QuicConnection test
- add PathMtuManager probe API test
- test XORObfuscator encode/decode roundtrip
- hook new tests into CMake

## Testing
- `cmake ..`
- `cmake --build . --target quic_connection_test xor_obfuscation_test path_mtu_probe_logic_test` *(fails: `quiche.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68632229bc708333ae00f49db32c6025