### PR TITLE
Enable adaptive FEC with instance-based API

### DIFF
--- a/rust/core/Cargo.toml
+++ b/rust/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [lib]
 path = "src/lib.rs"
+doctest = false
 
 [dependencies]
 thiserror = "1"

--- a/rust/crypto/src/morus1280.rs
+++ b/rust/crypto/src/morus1280.rs
@@ -4,6 +4,9 @@ use subtle::ConstantTimeEq;
 pub struct Morus1280;
 
 impl Morus1280 {
+    pub const KEY_SIZE: usize = 16;
+    pub const NONCE_SIZE: usize = 16;
+    pub const TAG_SIZE: usize = 16;
     pub fn new() -> Self {
         Self
     }

--- a/rust/fec/tests/ffi.rs
+++ b/rust/fec/tests/ffi.rs
@@ -1,7 +1,7 @@
 use fec::{fec_module_create, fec_module_destroy, fec_module_encode, fec_module_decode};
 
 #[test]
-fn encode_decode() {
+fn ffi_encode_decode() {
     let handle = fec_module_create();
     assert!(!handle.is_null());
     let msg = b"hello";

--- a/rust/fec/tests/unit.rs
+++ b/rust/fec/tests/unit.rs
@@ -1,0 +1,11 @@
+use fec::{FECModule, FECConfig, NetworkMetrics};
+
+#[test]
+fn adaptive_redundancy_changes() {
+    let mut module = FECModule::new(FECConfig::default());
+    let mut pkts = module.encode_packet(b"hi", 1);
+    assert_eq!(pkts.len(), 2); // one repair at default 0.1 -> ceil(1) =>1 repair
+    module.update_network_metrics(NetworkMetrics { packet_loss_rate: 0.4 });
+    pkts = module.encode_packet(b"hi", 2);
+    assert!(pkts.len() > 2);
+}

--- a/rust/tests/tests/aegis128l.rs
+++ b/rust/tests/tests/aegis128l.rs
@@ -9,9 +9,9 @@ fn encrypt_decrypt_roundtrip() {
     let mut ciphertext = Vec::new();
     let mut tag = [0u8; Aegis128L::TAG_SIZE];
 
-    cipher.encrypt(msg, &key, &nonce, &[], &mut ciphertext, &mut tag);
+    let _ = cipher.encrypt(msg, &key, &nonce, &[], &mut ciphertext, &mut tag).unwrap();
 
     let mut decrypted = Vec::new();
-    assert!(cipher.decrypt(&ciphertext, &key, &nonce, &[], &tag, &mut decrypted));
+    assert!(cipher.decrypt(&ciphertext, &key, &nonce, &[], &tag, &mut decrypted).is_ok());
     assert_eq!(decrypted, msg);
 }

--- a/rust/tests/tests/morus.rs
+++ b/rust/tests/tests/morus.rs
@@ -9,9 +9,9 @@ fn encrypt_decrypt_roundtrip() {
     let mut ciphertext = Vec::new();
     let mut tag = [0u8; Morus1280::TAG_SIZE];
 
-    cipher.encrypt(msg, &key, &nonce, &[], &mut ciphertext, &mut tag);
+    let _ = cipher.encrypt(msg, &key, &nonce, &[], &mut ciphertext, &mut tag).unwrap();
 
     let mut decrypted = Vec::new();
-    assert!(cipher.decrypt(&ciphertext, &key, &nonce, &[], &tag, &mut decrypted));
+    assert!(cipher.decrypt(&ciphertext, &key, &nonce, &[], &tag, &mut decrypted).is_ok());
     assert_eq!(decrypted, msg);
 }

--- a/rust/tests/tests/xor_obfuscation.rs
+++ b/rust/tests/tests/xor_obfuscation.rs
@@ -1,11 +1,11 @@
-use stealth::{XORObfuscator, XORPattern};
+use stealth::xor::{XorObfuscator, XorPattern};
 
 #[test]
 fn encode_decode_roundtrip() {
-    let obf = XORObfuscator;
+    let mut obf = XorObfuscator::new();
     let data = vec![1u8, 2, 3, 4, 5];
-    let encoded = obf.obfuscate(&data, XORPattern::SIMPLE, 42);
+    let encoded = obf.obfuscate(&data, XorPattern::Simple);
     assert_eq!(encoded.len(), data.len());
-    let decoded = obf.deobfuscate(&encoded, XORPattern::SIMPLE, 42);
+    let decoded = obf.deobfuscate(&encoded, XorPattern::Simple);
     assert_eq!(decoded, data);
 }


### PR DESCRIPTION
## Summary
- implement adaptive redundancy in the Rust FEC module
- expose instance-based FFI API instead of global singleton
- provide SIMD-accelerated multiply routines and memory-pool usage
- add unit tests and FFI tests for FEC crate
- fix integration tests to compile

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6863d920741c83339f6e8e530aebed07