### PR TITLE
Port MORUS ciphers to Rust

### DIFF
--- a/rust/crypto/src/morus.rs
+++ b/rust/crypto/src/morus.rs
@@ -4,6 +4,18 @@ use subtle::ConstantTimeEq;
 pub struct Morus;
 
 impl Morus {
+    pub const KEY_SIZE: usize = 16;
+    pub const NONCE_SIZE: usize = 16;
+    pub const TAG_SIZE: usize = 16;
+
+    const IV: u64 = 0x8040_0c06_0000_0000u64;
+    const RATE: usize = 16;
+    const PA_ROUNDS: usize = 12;
+    const PB_ROUNDS: usize = 8;
+    const ROUND_CONSTANTS: [u64; 12] = [
+        0xf0, 0xe1, 0xd2, 0xc3, 0xb4, 0xa5, 0x96, 0x87, 0x78, 0x69, 0x5a, 0x4b,
+    ];
+
     pub fn new() -> Self {
         Self
     }
@@ -11,43 +23,226 @@ impl Morus {
     pub fn encrypt(
         &self,
         plaintext: &[u8],
-        key: &[u8; 16],
-        nonce: &[u8; 16],
-        _ad: &[u8],
+        key: &[u8; Self::KEY_SIZE],
+        nonce: &[u8; Self::NONCE_SIZE],
+        ad: &[u8],
         ciphertext: &mut Vec<u8>,
-        tag: &mut [u8; 16],
+        tag: &mut [u8; Self::TAG_SIZE],
     ) -> Result<(), CryptoError> {
+        let mut state = [0u64; 5];
+        state[0] = Self::IV;
+        state[1] = Self::bytes_to_u64(&key[0..8]);
+        state[2] = Self::bytes_to_u64(&key[8..16]);
+        state[3] = Self::bytes_to_u64(&nonce[0..8]);
+        state[4] = Self::bytes_to_u64(&nonce[8..16]);
+
+        Self::morus_permutation(&mut state, Self::PA_ROUNDS);
+
+        state[3] ^= Self::bytes_to_u64(&key[0..8]);
+        state[4] ^= Self::bytes_to_u64(&key[8..16]);
+
+        if !ad.is_empty() {
+            let blocks = ad.len() / Self::RATE;
+            for i in 0..blocks {
+                state[0] ^= Self::bytes_to_u64(&ad[i * Self::RATE..i * Self::RATE + 8]);
+                state[1] ^= Self::bytes_to_u64(&ad[i * Self::RATE + 8..i * Self::RATE + 16]);
+                Self::morus_permutation(&mut state, Self::PB_ROUNDS);
+            }
+            if ad.len() % Self::RATE != 0 {
+                let mut padded = [0u8; Self::RATE];
+                let off = blocks * Self::RATE;
+                padded[..ad.len() % Self::RATE].copy_from_slice(&ad[off..]);
+                padded[ad.len() % Self::RATE] = 0x80;
+                state[0] ^= Self::bytes_to_u64(&padded[0..8]);
+                state[1] ^= Self::bytes_to_u64(&padded[8..16]);
+                Self::morus_permutation(&mut state, Self::PB_ROUNDS);
+            }
+        }
+
+        state[4] ^= 1;
+
         ciphertext.clear();
-        ciphertext.extend(
-            plaintext
-                .iter()
-                .enumerate()
-                .map(|(i, &b)| b ^ key[i % 16] ^ nonce[i % 16]),
-        );
-        tag.copy_from_slice(key);
+        let blocks = plaintext.len() / Self::RATE;
+        for i in 0..blocks {
+            state[0] ^= Self::bytes_to_u64(&plaintext[i * Self::RATE..i * Self::RATE + 8]);
+            state[1] ^= Self::bytes_to_u64(&plaintext[i * Self::RATE + 8..i * Self::RATE + 16]);
+
+            ciphertext.extend_from_slice(&Self::u64_to_bytes(state[0]));
+            ciphertext.extend_from_slice(&Self::u64_to_bytes(state[1]));
+
+            Self::morus_permutation(&mut state, Self::PB_ROUNDS);
+        }
+
+        if plaintext.len() % Self::RATE != 0 {
+            let mut padded = [0u8; Self::RATE];
+            let off = blocks * Self::RATE;
+            padded[..plaintext.len() % Self::RATE]
+                .copy_from_slice(&plaintext[off..off + plaintext.len() % Self::RATE]);
+            padded[plaintext.len() % Self::RATE] = 0x80;
+
+            state[0] ^= Self::bytes_to_u64(&padded[0..8]);
+            state[1] ^= Self::bytes_to_u64(&padded[8..16]);
+
+            let ct_block0 = Self::u64_to_bytes(state[0]);
+            let ct_block1 = Self::u64_to_bytes(state[1]);
+            ciphertext.extend_from_slice(&ct_block0[..]);
+            ciphertext.extend_from_slice(&ct_block1[..]);
+            ciphertext.truncate(plaintext.len());
+        }
+
+        state[1] ^= Self::bytes_to_u64(&key[0..8]);
+        state[2] ^= Self::bytes_to_u64(&key[8..16]);
+        Self::morus_permutation(&mut state, Self::PA_ROUNDS);
+        state[3] ^= Self::bytes_to_u64(&key[0..8]);
+        state[4] ^= Self::bytes_to_u64(&key[8..16]);
+
+        let tag_bytes0 = Self::u64_to_bytes(state[3]);
+        let tag_bytes1 = Self::u64_to_bytes(state[4]);
+        tag.copy_from_slice(&[tag_bytes0, tag_bytes1].concat()[0..Self::TAG_SIZE]);
         Ok(())
     }
 
     pub fn decrypt(
         &self,
         ciphertext: &[u8],
-        key: &[u8; 16],
-        nonce: &[u8; 16],
-        _ad: &[u8],
-        tag: &[u8; 16],
+        key: &[u8; Self::KEY_SIZE],
+        nonce: &[u8; Self::NONCE_SIZE],
+        ad: &[u8],
+        tag: &[u8; Self::TAG_SIZE],
         plaintext: &mut Vec<u8>,
     ) -> Result<(), CryptoError> {
+        let mut state = [0u64; 5];
+        state[0] = Self::IV;
+        state[1] = Self::bytes_to_u64(&key[0..8]);
+        state[2] = Self::bytes_to_u64(&key[8..16]);
+        state[3] = Self::bytes_to_u64(&nonce[0..8]);
+        state[4] = Self::bytes_to_u64(&nonce[8..16]);
+
+        Self::morus_permutation(&mut state, Self::PA_ROUNDS);
+
+        state[3] ^= Self::bytes_to_u64(&key[0..8]);
+        state[4] ^= Self::bytes_to_u64(&key[8..16]);
+
+        if !ad.is_empty() {
+            let blocks = ad.len() / Self::RATE;
+            for i in 0..blocks {
+                state[0] ^= Self::bytes_to_u64(&ad[i * Self::RATE..i * Self::RATE + 8]);
+                state[1] ^= Self::bytes_to_u64(&ad[i * Self::RATE + 8..i * Self::RATE + 16]);
+                Self::morus_permutation(&mut state, Self::PB_ROUNDS);
+            }
+            if ad.len() % Self::RATE != 0 {
+                let mut padded = [0u8; Self::RATE];
+                let off = blocks * Self::RATE;
+                padded[..ad.len() % Self::RATE].copy_from_slice(&ad[off..]);
+                padded[ad.len() % Self::RATE] = 0x80;
+                state[0] ^= Self::bytes_to_u64(&padded[0..8]);
+                state[1] ^= Self::bytes_to_u64(&padded[8..16]);
+                Self::morus_permutation(&mut state, Self::PB_ROUNDS);
+            }
+        }
+
+        state[4] ^= 1;
+
         plaintext.clear();
-        plaintext.extend(
-            ciphertext
-                .iter()
-                .enumerate()
-                .map(|(i, &b)| b ^ key[i % 16] ^ nonce[i % 16]),
-        );
-        if tag.ct_eq(key).unwrap_u8() == 1 {
+        let blocks = ciphertext.len() / Self::RATE;
+        for i in 0..blocks {
+            let ct0 = Self::bytes_to_u64(&ciphertext[i * Self::RATE..i * Self::RATE + 8]);
+            let ct1 = Self::bytes_to_u64(&ciphertext[i * Self::RATE + 8..i * Self::RATE + 16]);
+
+            plaintext.extend_from_slice(&Self::u64_to_bytes(state[0] ^ ct0));
+            plaintext.extend_from_slice(&Self::u64_to_bytes(state[1] ^ ct1));
+
+            state[0] = ct0;
+            state[1] = ct1;
+
+            Self::morus_permutation(&mut state, Self::PB_ROUNDS);
+        }
+
+        if ciphertext.len() % Self::RATE != 0 {
+            let mut ct_block = [0u8; Self::RATE];
+            let off = blocks * Self::RATE;
+            ct_block[..ciphertext.len() % Self::RATE]
+                .copy_from_slice(&ciphertext[off..]);
+
+            let mut state_bytes = [0u8; Self::RATE];
+            state_bytes[..8].copy_from_slice(&Self::u64_to_bytes(state[0]));
+            state_bytes[8..16].copy_from_slice(&Self::u64_to_bytes(state[1]));
+
+            for i in 0..ciphertext.len() % Self::RATE {
+                plaintext.push(state_bytes[i] ^ ct_block[i]);
+                state_bytes[i] = ct_block[i];
+            }
+            state_bytes[ciphertext.len() % Self::RATE] = 0x80;
+            state[0] = Self::bytes_to_u64(&state_bytes[0..8]);
+            state[1] = Self::bytes_to_u64(&state_bytes[8..16]);
+        }
+
+        state[1] ^= Self::bytes_to_u64(&key[0..8]);
+        state[2] ^= Self::bytes_to_u64(&key[8..16]);
+        Self::morus_permutation(&mut state, Self::PA_ROUNDS);
+        state[3] ^= Self::bytes_to_u64(&key[0..8]);
+        state[4] ^= Self::bytes_to_u64(&key[8..16]);
+
+        let mut computed_tag = [0u8; Self::TAG_SIZE];
+        computed_tag[..8].copy_from_slice(&Self::u64_to_bytes(state[3]));
+        computed_tag[8..].copy_from_slice(&Self::u64_to_bytes(state[4]));
+
+        if tag.ct_eq(&computed_tag).unwrap_u8() == 1 {
             Ok(())
         } else {
             Err(CryptoError::InvalidTag)
         }
+    }
+
+    fn morus_permutation(state: &mut [u64; 5], rounds: usize) {
+        for i in (12 - rounds)..12 {
+            state[2] ^= Self::ROUND_CONSTANTS[i];
+
+            state[0] ^= state[4];
+            state[4] ^= state[3];
+            state[2] ^= state[1];
+
+            let t0 = state[0];
+            let t1 = state[1];
+            let t2 = state[2];
+            let t3 = state[3];
+            let t4 = state[4];
+
+            state[0] = t0 ^ ((!t1) & t2);
+            state[1] = t1 ^ ((!t2) & t3);
+            state[2] = t2 ^ ((!t3) & t4);
+            state[3] = t3 ^ ((!t4) & t0);
+            state[4] = t4 ^ ((!t0) & t1);
+
+            state[1] ^= state[0];
+            state[0] ^= state[4];
+            state[3] ^= state[2];
+            state[2] = !state[2];
+
+            state[0] ^= Self::rotr64(state[0], 19) ^ Self::rotr64(state[0], 28);
+            state[1] ^= Self::rotr64(state[1], 61) ^ Self::rotr64(state[1], 39);
+            state[2] ^= Self::rotr64(state[2], 1) ^ Self::rotr64(state[2], 6);
+            state[3] ^= Self::rotr64(state[3], 10) ^ Self::rotr64(state[3], 17);
+            state[4] ^= Self::rotr64(state[4], 7) ^ Self::rotr64(state[4], 41);
+        }
+    }
+
+    #[inline]
+    fn bytes_to_u64(bytes: &[u8]) -> u64 {
+        let mut res = 0u64;
+        for &b in bytes.iter().take(8) {
+            res = (res << 8) | b as u64;
+        }
+        res
+    }
+
+    #[inline]
+    fn u64_to_bytes(v: u64) -> [u8; 8] {
+        v.to_be_bytes()
+    }
+
+    #[inline]
+    fn rotr64(v: u64, s: u32) -> u64 {
+        (v >> s) | (v << (64 - s))
     }
 }

--- a/rust/crypto/src/morus1280.rs
+++ b/rust/crypto/src/morus1280.rs
@@ -4,6 +4,21 @@ use subtle::ConstantTimeEq;
 pub struct Morus1280;
 
 impl Morus1280 {
+    pub const KEY_SIZE: usize = 16;
+    pub const NONCE_SIZE: usize = 16;
+    pub const TAG_SIZE: usize = 16;
+
+    const RATE: usize = 32;
+    const ROUNDS: usize = 5;
+
+    const IV: [u64; 20] = [
+        0x0d08050302010100u64, 0x6279e99059372215u64, 0xf12fc26d55183ddbu64, 0xdd28b57342311120u64,
+        0x5470917e43281e90u64, 0x8d9b7abacc626ab9u64, 0x142c3ba227d7cdcfu64, 0xf881e24d45a7ed8eu64,
+        0x3c24ba1e0776a298u64, 0x8427a4364c417daeu64, 0x4d84c3ce9a7a26b8u64, 0x19dc8ce6c1356be5u64,
+        0x874761517311cf32u64, 0x6d113b0f462f2c4au64, 0xc2b4ac11f1c13289u64, 0x915f2d99c2403f37u64,
+        0x6d9b4cf2a8b8e8e9u64, 0x79607b532d176b19u64, 0xb49ac2e85c91745fu64, 0x7bcd371c9a220496u64,
+    ];
+
     pub fn new() -> Self {
         Self
     }
@@ -11,43 +26,313 @@ impl Morus1280 {
     pub fn encrypt(
         &self,
         plaintext: &[u8],
-        key: &[u8; 16],
-        nonce: &[u8; 16],
-        _ad: &[u8],
+        key: &[u8; Self::KEY_SIZE],
+        nonce: &[u8; Self::NONCE_SIZE],
+        ad: &[u8],
         ciphertext: &mut Vec<u8>,
-        tag: &mut [u8; 16],
+        tag: &mut [u8; Self::TAG_SIZE],
     ) -> Result<(), CryptoError> {
-        ciphertext.clear();
-        ciphertext.extend(
-            plaintext
-                .iter()
-                .enumerate()
-                .map(|(i, &b)| b ^ key[i % 16] ^ nonce[i % 16]),
-        );
-        tag.copy_from_slice(key);
+        let mut state = Self::init_state(key, nonce);
+
+        if !ad.is_empty() {
+            Self::process_ad(&mut state, ad);
+        }
+
+        Self::process_pt(&mut state, plaintext, ciphertext);
+        Self::finalize(&mut state, ad.len(), plaintext.len(), tag);
         Ok(())
     }
 
     pub fn decrypt(
         &self,
         ciphertext: &[u8],
-        key: &[u8; 16],
-        nonce: &[u8; 16],
-        _ad: &[u8],
-        tag: &[u8; 16],
+        key: &[u8; Self::KEY_SIZE],
+        nonce: &[u8; Self::NONCE_SIZE],
+        ad: &[u8],
+        tag: &[u8; Self::TAG_SIZE],
         plaintext: &mut Vec<u8>,
     ) -> Result<(), CryptoError> {
-        plaintext.clear();
-        plaintext.extend(
-            ciphertext
-                .iter()
-                .enumerate()
-                .map(|(i, &b)| b ^ key[i % 16] ^ nonce[i % 16]),
-        );
-        if tag.ct_eq(key).unwrap_u8() == 1 {
+        let mut state = Self::init_state(key, nonce);
+
+        if !ad.is_empty() {
+            Self::process_ad(&mut state, ad);
+        }
+
+        Self::process_ct(&mut state, ciphertext, plaintext);
+
+        let mut computed_tag = [0u8; Self::TAG_SIZE];
+        Self::finalize(&mut state, ad.len(), ciphertext.len(), &mut computed_tag);
+        if tag.ct_eq(&computed_tag).unwrap_u8() == 1 {
             Ok(())
         } else {
             Err(CryptoError::InvalidTag)
+        }
+    }
+
+    fn init_state(key: &[u8; Self::KEY_SIZE], nonce: &[u8; Self::NONCE_SIZE]) -> [u64; 20] {
+        let mut state = Self::IV;
+        let mut key_words = [0u64; 2];
+        let mut nonce_words = [0u64; 2];
+        Self::bytes_to_words(&mut key_words, key);
+        Self::bytes_to_words(&mut nonce_words, nonce);
+
+        state[0] ^= key_words[0];
+        state[1] ^= key_words[1];
+        state[4] ^= key_words[0];
+        state[5] ^= key_words[1];
+
+        state[8] ^= nonce_words[0];
+        state[9] ^= nonce_words[1];
+        state[12] ^= nonce_words[0];
+        state[13] ^= nonce_words[1];
+
+        for _ in 0..16 {
+            Self::permutation(&mut state);
+        }
+        state
+    }
+
+    fn process_ad(state: &mut [u64; 20], ad: &[u8]) {
+        let blocks = ad.len() / Self::RATE;
+        for i in 0..blocks {
+            let mut block = [0u64; 4];
+            Self::bytes_to_words(&mut block, &ad[i * Self::RATE..i * Self::RATE + Self::RATE]);
+            let mut tmp = [0u64; 4];
+            Self::xor_256(&mut tmp, &state[0..4], &block);
+            state[0..4].copy_from_slice(&tmp);
+            Self::permutation(state);
+        }
+        if ad.len() % Self::RATE != 0 {
+            let mut padded = [0u8; Self::RATE];
+            let off = blocks * Self::RATE;
+            padded[..ad.len() % Self::RATE].copy_from_slice(&ad[off..]);
+            padded[ad.len() % Self::RATE] = 0x80;
+            let mut block = [0u64; 4];
+            Self::bytes_to_words(&mut block, &padded);
+            let mut tmp = [0u64; 4];
+            Self::xor_256(&mut tmp, &state[0..4], &block);
+            state[0..4].copy_from_slice(&tmp);
+            Self::permutation(state);
+        }
+    }
+
+    fn process_pt(state: &mut [u64; 20], pt: &[u8], ct: &mut Vec<u8>) {
+        let blocks = pt.len() / Self::RATE;
+        ct.clear();
+        for i in 0..blocks {
+            let mut pt_words = [0u64; 4];
+            Self::bytes_to_words(&mut pt_words, &pt[i * Self::RATE..i * Self::RATE + Self::RATE]);
+
+            let mut keystream = [0u64; 4];
+            Self::xor_256(&mut keystream, &state[0..4], &state[4..8]);
+            let mut ks_tmp = [0u64; 4];
+            Self::xor_256(&mut ks_tmp, &keystream, &state[8..12]);
+            keystream.copy_from_slice(&ks_tmp);
+
+            let mut ct_block = [0u64; 4];
+            Self::xor_256(&mut ct_block, &pt_words, &keystream);
+            Self::words_to_bytes_vec(ct, &ct_block);
+
+            let mut tmp = [0u64;4];
+            Self::xor_256(&mut tmp, &state[0..4], &pt_words);
+            state[0..4].copy_from_slice(&tmp);
+            Self::permutation(state);
+        }
+
+        if pt.len() % Self::RATE != 0 {
+            let mut pt_block = [0u8; Self::RATE];
+            let off = blocks * Self::RATE;
+            pt_block[..pt.len() % Self::RATE].copy_from_slice(&pt[off..]);
+            let mut pt_words = [0u64; 4];
+            Self::bytes_to_words(&mut pt_words, &pt_block);
+
+            let mut keystream = [0u64; 4];
+            Self::xor_256(&mut keystream, &state[0..4], &state[4..8]);
+            let mut ks_tmp = [0u64;4];
+            Self::xor_256(&mut ks_tmp, &keystream, &state[8..12]);
+            keystream.copy_from_slice(&ks_tmp);
+
+            let mut ct_words = [0u64; 4];
+            Self::xor_256(&mut ct_words, &pt_words, &keystream);
+            let mut tmp = Vec::new();
+            Self::words_to_bytes_vec(&mut tmp, &ct_words);
+            ct.extend_from_slice(&tmp[..pt.len() % Self::RATE]);
+
+            pt_block[pt.len() % Self::RATE] = 0x80;
+            let mut padded = [0u64; 4];
+            Self::bytes_to_words(&mut padded, &pt_block);
+            let mut tmp_state = [0u64;4];
+            Self::xor_256(&mut tmp_state, &state[0..4], &padded);
+            state[0..4].copy_from_slice(&tmp_state);
+            Self::permutation(state);
+        }
+    }
+
+    fn process_ct(state: &mut [u64; 20], ct: &[u8], pt: &mut Vec<u8>) {
+        let blocks = ct.len() / Self::RATE;
+        pt.clear();
+        for i in 0..blocks {
+            let mut ct_words = [0u64; 4];
+            Self::bytes_to_words(&mut ct_words, &ct[i * Self::RATE..i * Self::RATE + Self::RATE]);
+
+            let mut keystream = [0u64; 4];
+            Self::xor_256(&mut keystream, &state[0..4], &state[4..8]);
+            let mut ks_tmp = [0u64;4];
+            Self::xor_256(&mut ks_tmp, &keystream, &state[8..12]);
+            keystream.copy_from_slice(&ks_tmp);
+
+            let mut pt_words = [0u64; 4];
+            Self::xor_256(&mut pt_words, &ct_words, &keystream);
+            Self::words_to_bytes_vec(pt, &pt_words);
+
+            let mut tmp_state = [0u64;4];
+            Self::xor_256(&mut tmp_state, &state[0..4], &ct_words);
+            state[0..4].copy_from_slice(&tmp_state);
+            Self::permutation(state);
+        }
+
+        if ct.len() % Self::RATE != 0 {
+            let mut ct_block = [0u8; Self::RATE];
+            let off = blocks * Self::RATE;
+            ct_block[..ct.len() % Self::RATE].copy_from_slice(&ct[off..]);
+            let mut ct_words = [0u64; 4];
+            Self::bytes_to_words(&mut ct_words, &ct_block);
+
+            let mut keystream = [0u64; 4];
+            Self::xor_256(&mut keystream, &state[0..4], &state[4..8]);
+            let mut ks_tmp2 = [0u64;4];
+            Self::xor_256(&mut ks_tmp2, &keystream, &state[8..12]);
+            keystream.copy_from_slice(&ks_tmp2);
+
+            let mut pt_words = [0u64; 4];
+            Self::xor_256(&mut pt_words, &ct_words, &keystream);
+            let mut tmp = Vec::new();
+            Self::words_to_bytes_vec(&mut tmp, &pt_words);
+            pt.extend_from_slice(&tmp[..ct.len() % Self::RATE]);
+
+            ct_block[ct.len() % Self::RATE] = 0x80;
+            let mut padded = [0u64; 4];
+            Self::bytes_to_words(&mut padded, &ct_block);
+            let mut tmp_state2 = [0u64;4];
+            Self::xor_256(&mut tmp_state2, &state[0..4], &padded);
+            state[0..4].copy_from_slice(&tmp_state2);
+            Self::permutation(state);
+        }
+    }
+
+    fn finalize(state: &mut [u64; 20], ad_len: usize, pt_len: usize, tag: &mut [u8; Self::TAG_SIZE]) {
+        let mut lengths = [0u64; 4];
+        lengths[0] = (ad_len as u64) * 8;
+        lengths[2] = (pt_len as u64) * 8;
+
+        for i in 0..4 {
+            state[16 + i] ^= lengths[i];
+        }
+
+        for _ in 0..10 {
+            Self::permutation(state);
+        }
+
+        let tag_words = [
+            state[0] ^ state[4] ^ state[8] ^ state[12] ^ state[16],
+            state[1] ^ state[5] ^ state[9] ^ state[13] ^ state[17],
+        ];
+        let mut tmp = Vec::new();
+        Self::words_to_bytes_vec(&mut tmp, &tag_words);
+        tag.copy_from_slice(&tmp[..Self::TAG_SIZE]);
+    }
+
+    fn permutation(state: &mut [u64; 20]) {
+        for round in 0..Self::ROUNDS {
+            let mut tmp0 = [0u64; 4];
+            let mut tmp1 = [0u64; 4];
+            let mut tmp2 = [0u64; 4];
+            Self::and_256(&mut tmp0, &state[4..8], &state[8..12]);
+            Self::rotl_256(&mut tmp1, &state[4..8], 13);
+            Self::xor_256(&mut tmp2, &state[0..4], &tmp0);
+            let mut tmp3 = [0u64;4];
+            Self::xor_256(&mut tmp3, &tmp2, &state[12..16]);
+            tmp2.copy_from_slice(&tmp3);
+            Self::xor_256(&mut tmp3, &tmp2, &tmp1);
+            state[0..4].copy_from_slice(&tmp3);
+
+            let mut tmp_state = [0u64; 4];
+            tmp_state.copy_from_slice(&state[0..4]);
+            state.copy_within(4..20, 0);
+            state[16..20].copy_from_slice(&tmp_state);
+
+            let src_block: [u64;4] = state[0..4].try_into().unwrap();
+            Self::rotl_256(&mut state[0..4], &src_block, ((round + 1) * 7) as i32);
+        }
+    }
+
+    #[inline]
+    fn rotl_256(dst: &mut [u64], src: &[u64], bits: i32) {
+        if bits == 0 {
+            dst.copy_from_slice(src);
+            return;
+        }
+        let word_shift = (bits / 64) as usize;
+        let bit_shift = bits % 64;
+        for i in 0..4 {
+            let src_idx = (i + 4 - word_shift) % 4;
+            if bit_shift == 0 {
+                dst[i] = src[src_idx];
+            } else {
+                let next_idx = (src_idx + 1) % 4;
+                dst[i] = (src[src_idx] << bit_shift) | (src[next_idx] >> (64 - bit_shift));
+            }
+        }
+    }
+
+    #[inline]
+    fn xor_256(dst: &mut [u64], a: &[u64], b: &[u64]) {
+        #[cfg(all(target_arch="x86_64", target_feature="avx2"))]
+        unsafe {
+            use std::arch::x86_64::*;
+            if dst.len() == 4 {
+                let va = _mm256_loadu_si256(a.as_ptr() as *const __m256i);
+                let vb = _mm256_loadu_si256(b.as_ptr() as *const __m256i);
+                let vc = _mm256_xor_si256(va, vb);
+                _mm256_storeu_si256(dst.as_mut_ptr() as *mut __m256i, vc);
+                return;
+            }
+        }
+        for i in 0..dst.len() {
+            dst[i] = a[i] ^ b[i];
+        }
+    }
+
+    #[inline]
+    fn and_256(dst: &mut [u64], a: &[u64], b: &[u64]) {
+        #[cfg(all(target_arch="x86_64", target_feature="avx2"))]
+        unsafe {
+            use std::arch::x86_64::*;
+            if dst.len() == 4 {
+                let va = _mm256_loadu_si256(a.as_ptr() as *const __m256i);
+                let vb = _mm256_loadu_si256(b.as_ptr() as *const __m256i);
+                let vc = _mm256_and_si256(va, vb);
+                _mm256_storeu_si256(dst.as_mut_ptr() as *mut __m256i, vc);
+                return;
+            }
+        }
+        for i in 0..dst.len() {
+            dst[i] = a[i] & b[i];
+        }
+    }
+
+    #[inline]
+    fn bytes_to_words(words: &mut [u64], bytes: &[u8]) {
+        for w in words.iter_mut() { *w = 0; }
+        for (i, b) in bytes.iter().enumerate().take(words.len() * 8) {
+            words[i / 8] |= (*b as u64) << ((i % 8) * 8);
+        }
+    }
+
+    #[inline]
+    fn words_to_bytes_vec(out: &mut Vec<u8>, words: &[u64]) {
+        for i in 0..words.len() * 8 {
+            out.push(((words[i / 8] >> ((i % 8) * 8)) & 0xFF) as u8);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement the MORUS-1280 and MORUS permutation logic in Rust
- expose constants for key/nonce/tag sizes
- add optional AVX2 paths in XOR/AND helpers

## Testing
- `cargo test -p crypto` *(fails: encrypt_decrypt_roundtrip)*

------
https://chatgpt.com/codex/tasks/task_e_6863da2bc0f08333ac1e1876a907709f