### PR TITLE
Mark legacy crypto headers deprecated

### DIFF
--- a/crypto/aegis128l.hpp
+++ b/crypto/aegis128l.hpp
@@ -29,6 +29,7 @@ namespace crypto {
  * - Primäre Wahl für ARM-Systeme mit Crypto Extensions
  * - Gute Wahl für x86-Systeme ohne VAES
  */
+[[deprecated("Use Rust implementation in rust/crypto")]]
 class AEGIS128L {
 public:
     static constexpr size_t KEY_SIZE = 16;    // 128-bit key

--- a/crypto/aegis128x.hpp
+++ b/crypto/aegis128x.hpp
@@ -26,6 +26,7 @@ namespace crypto {
  * - Nur auf x86-Systemen mit VAES-Unterstützung
  * - Für ARM-Systeme sollte AEGIS-128L verwendet werden
  */
+[[deprecated("Use Rust implementation in rust/crypto")]]
 class AEGIS128X {
 public:
     static constexpr size_t KEY_SIZE = 16;    // 128-bit key

--- a/crypto/morus.hpp
+++ b/crypto/morus.hpp
@@ -5,6 +5,7 @@
 namespace quicfuscate {
 namespace crypto {
 
+[[deprecated("Use Rust implementation in rust/crypto")]]
 class MORUS {
 public:
     MORUS();

--- a/crypto/morus1280.hpp
+++ b/crypto/morus1280.hpp
@@ -6,6 +6,7 @@
 namespace quicfuscate {
 namespace crypto {
 
+[[deprecated("Use Rust implementation in rust/crypto")]]
 class MORUS1280 {
 public:
     MORUS1280();


### PR DESCRIPTION
## Summary
- mark old C++ crypto headers as deprecated since Rust versions exist

## Testing
- `cargo build --workspace --quiet`
- `cargo test --workspace --quiet` *(fails: encrypt_decrypt_vectors)*

------
https://chatgpt.com/codex/tasks/task_e_6863dfb5b13c833394d127151f91466d