### PR TITLE
Replace memcpy usage with std::copy

### DIFF
--- a/fec/FEC_Modul.cpp
+++ b/fec/FEC_Modul.cpp
@@ -316,7 +316,7 @@ void GaloisField::multiply_vector_scalar_neon(uint8_t* dst, const uint8_t* src, 
         return;
     }
     if (scalar == 1) {
-        memcpy(dst, src, length);
+        std::copy(src, src + length, dst);
         return;
     }
     
@@ -351,7 +351,7 @@ void GaloisField::multiply_vector_scalar_avx2(uint8_t* dst, const uint8_t* src, 
         return;
     }
     if (scalar == 1) {
-        memcpy(dst, src, length);
+        std::copy(src, src + length, dst);
         return;
     }
     
@@ -772,7 +772,9 @@ extern "C" {
         try {
             auto stats = global_fec_module->get_statistics();
             size_t copy_size = std::min(buffer_size, sizeof(stats));
-            memcpy(stats_buffer, &stats, copy_size);
+            std::copy_n(reinterpret_cast<const uint8_t*>(&stats),
+                       copy_size,
+                       reinterpret_cast<uint8_t*>(stats_buffer));
             return 0;
         } catch (...) {
             return -1;

--- a/stealth/XOR_Obfuscation.cpp
+++ b/stealth/XOR_Obfuscation.cpp
@@ -350,7 +350,9 @@ private:
         
         // Derive key from current key and context
         std::vector<uint8_t> context_bytes(sizeof(context_id));
-        std::memcpy(context_bytes.data(), &context_id, sizeof(context_id));
+        std::copy(reinterpret_cast<const uint8_t*>(&context_id),
+                  reinterpret_cast<const uint8_t*>(&context_id) + sizeof(context_id),
+                  context_bytes.data());
         
         return XORKeyDerivation::derive_key(context_id, current_key_, 32);
     }


### PR DESCRIPTION
## Summary
- refactor FEC module and XOR obfuscation to use `std::copy`
- drop remaining raw `memcpy` calls

## Testing
- `cargo test --quiet` *(fails: feature `stdarch_x86_avx512` requires nightly)*
- `cmake ..` *(passes)*
- `make -j$(nproc)` *(fails: missing `quiche.h`)*

------
https://chatgpt.com/codex/tasks/task_e_686438579d2883338c1b063f34bb84ed