### PR TITLE
Introduce constants for common sizes

### DIFF
--- a/core/quic_connection.hpp
+++ b/core/quic_connection.hpp
@@ -197,7 +197,8 @@ public:
     void flush_burst_buffer();
     
     // Memory-Pool-Methoden
-    void init_memory_pool(size_t block_size = 4096, size_t initial_blocks = 16);
+    void init_memory_pool(size_t block_size = DEFAULT_MEMORY_BLOCK_SIZE,
+                          size_t initial_blocks = 16);
     void* allocate_from_pool();
     void deallocate_to_pool(void* block);
     

--- a/core/quic_connection_impl.cpp
+++ b/core/quic_connection_impl.cpp
@@ -328,7 +328,7 @@ void QuicConnection::init_memory_pool() {
         MemoryPoolConfig config;
         config.initial_pool_size = 1024 * 1024; // 1MB
         config.max_pool_size = 16 * 1024 * 1024; // 16MB
-        config.block_size = 4096; // 4KB blocks
+        config.block_size = DEFAULT_MEMORY_BLOCK_SIZE; // 4KB blocks
         config.alignment = 64; // Cache line alignment
         
         memory_pool_ = std::make_unique<MemoryPool>(config);

--- a/core/quic_constants.hpp
+++ b/core/quic_constants.hpp
@@ -77,6 +77,15 @@ inline constexpr size_t DEFAULT_MAX_CONCURRENT_STREAMS = 1000;
 // Default number of iterations for PBKDF2 operations.
 inline constexpr size_t DEFAULT_PBKDF2_ITERATIONS = 10000;
 
+// Default block size used for memory pool allocations (bytes).
+inline constexpr size_t DEFAULT_MEMORY_BLOCK_SIZE = 4096;
+
+// Default QPACK dynamic table size for header compression (bytes).
+inline constexpr size_t DEFAULT_QPACK_DYNAMIC_TABLE_SIZE = 4096;
+
+// Default maximum burst size when using burst buffering (bytes).
+inline constexpr size_t DEFAULT_MAX_BURST_SIZE = 4096;
+
 } // namespace quicfuscate
 
 #endif // QUIC_CONSTANTS_HPP

--- a/optimize/unified_optimizations.hpp
+++ b/optimize/unified_optimizations.hpp
@@ -27,6 +27,7 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 #include "../core/error_handling.hpp"
+#include "../core/quic_constants.hpp"
 
 #ifdef __ARM_NEON
 #include <arm_neon.h>
@@ -895,7 +896,7 @@ private:
 struct UnifiedOptimizationConfig {
     // Memory settings
     size_t memory_pool_size = 16 * 1024 * 1024;
-    size_t memory_block_size = 4096;
+    size_t memory_block_size = DEFAULT_MEMORY_BLOCK_SIZE;
     bool use_zero_copy = true;
     
     // Threading settings
@@ -912,7 +913,7 @@ struct UnifiedOptimizationConfig {
     bool enable_prefetching = true;
     
     // QPACK settings
-    size_t qpack_dynamic_table_size = 4096;
+    size_t qpack_dynamic_table_size = DEFAULT_QPACK_DYNAMIC_TABLE_SIZE;
     bool qpack_use_huffman = true;
     
     // Zero-RTT settings
@@ -1033,7 +1034,7 @@ namespace simd {
 namespace memory {
     struct MemoryPoolConfig {
         size_t pool_size = 1024 * 1024;
-        size_t block_size = 4096;
+        size_t block_size = DEFAULT_MEMORY_BLOCK_SIZE;
         bool numa_aware = true;
     };
     
@@ -1148,7 +1149,7 @@ struct BurstConfig {
     uint32_t max_burst_interval_ms = 200;
     
     size_t min_burst_size = 512;
-    size_t max_burst_size = 4096;
+    size_t max_burst_size = DEFAULT_MAX_BURST_SIZE;
     size_t optimal_burst_size = 1400;
     
     BurstFrameType frame_type = BurstFrameType::HTTP3_CHUNKED;


### PR DESCRIPTION
## Summary
- extract magic numbers in core and optimize modules
- define reusable constants for memory block sizes, QPACK table size, and burst size
- replace numeric literals with the new constants

## Testing
- `cargo build --workspace` *(fails: `crypto` crate uses nightly-only features)*
- `cmake --build .` *(fails: errors in `cipher_suite_selector.cpp`)*

------
https://chatgpt.com/codex/tasks/task_e_68643857e5bc8333937d63c0f609be65