### PR TITLE
Refactor QuicUnifiedManager to use Result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,3 +164,7 @@ add_test(NAME xor_obfuscation_test COMMAND xor_obfuscation_test)
 add_executable(path_mtu_probe_logic_test tests/path_mtu_probe_logic_test.cpp)
 target_link_libraries(path_mtu_probe_logic_test PRIVATE gtest_main)
 add_test(NAME path_mtu_probe_logic_test COMMAND path_mtu_probe_logic_test)
+
+add_executable(quic_unified_manager_test tests/quic_unified_manager_test.cpp)
+target_link_libraries(quic_unified_manager_test PRIVATE gtest_main)
+add_test(NAME quic_unified_manager_test COMMAND quic_unified_manager_test)

--- a/tests/quic_unified_manager_test.cpp
+++ b/tests/quic_unified_manager_test.cpp
@@ -1,0 +1,23 @@
+#include "../core/quic_core_types.hpp"
+#include <gtest/gtest.h>
+
+using namespace quicfuscate;
+
+TEST(QuicUnifiedManagerTest, GetIntegrationFailsWhenUninitialized) {
+    auto& manager = QuicUnifiedManager::instance();
+    manager.shutdown();
+    auto result = manager.get_integration();
+    EXPECT_FALSE(result.success());
+}
+
+TEST(QuicUnifiedManagerTest, InitializeAndRetrieve) {
+    auto& manager = QuicUnifiedManager::instance();
+    manager.shutdown();
+    std::map<std::string, std::string> cfg;
+    auto init_result = manager.initialize(cfg);
+    ASSERT_TRUE(init_result.success());
+    auto get_result = manager.get_integration();
+    ASSERT_TRUE(get_result.success());
+    EXPECT_NE(get_result.value(), nullptr);
+    manager.shutdown();
+}


### PR DESCRIPTION
## Summary
- return `Result<void>` from `QuicUnifiedManager::initialize`
- propagate failure via `ErrorInfo` objects
- add unit test covering the unified manager error handling

## Testing
- `cmake -S . -B build`
- `cmake --build build --target quic_unified_manager_test` *(fails: fatal error: quiche.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6864385682188333b7da76fcae718776