### PR TITLE
Add Path MTU manager logic to Rust core crate

### DIFF
--- a/rust/core/tests/path_mtu_manager.rs
+++ b/rust/core/tests/path_mtu_manager.rs
@@ -1,4 +1,4 @@
-use core::{PathMtuManager, DEFAULT_MIN_MTU, DEFAULT_MAX_MTU};
+use core::{PathMtuManager, DEFAULT_MAX_MTU, DEFAULT_MIN_MTU};
 
 #[test]
 fn constants_range() {
@@ -8,7 +8,17 @@ fn constants_range() {
 
 #[test]
 fn probe_methods_exist() {
-    let mgr = PathMtuManager::new();
+    let mut mgr = PathMtuManager::new();
     let id = mgr.send_probe(1200, false);
     mgr.handle_probe_response(id, true, false);
+}
+
+#[test]
+fn enable_bidirectional() {
+    let mut mgr = PathMtuManager::new();
+    mgr.enable_bidirectional_discovery(true);
+    assert!(mgr.is_bidirectional_discovery_enabled());
+    mgr.set_mtu_size(1300, true);
+    assert_eq!(mgr.get_outgoing_mtu(), 1300);
+    assert_eq!(mgr.get_incoming_mtu(), 1300);
 }

--- a/rust/tests/tests/path_mtu_probe_logic.rs
+++ b/rust/tests/tests/path_mtu_probe_logic.rs
@@ -2,7 +2,7 @@ use core::PathMtuManager;
 
 #[test]
 fn has_probe_methods() {
-    let mgr = PathMtuManager::new();
+    let mut mgr = PathMtuManager::new();
     let id = mgr.send_probe(1200, false);
     mgr.handle_probe_response(id, true, false);
 }

--- a/rust/tests/tests/quic_connection.rs
+++ b/rust/tests/tests/quic_connection.rs
@@ -2,7 +2,25 @@ use core::{QuicConfig, QuicConnection};
 
 #[test]
 fn constructible() {
-    let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+    let cfg = QuicConfig {
+        server_name: "localhost".into(),
+        port: 443,
+    };
     let conn = QuicConnection::new(cfg);
     assert!(conn.is_ok());
+}
+
+#[test]
+fn zero_copy_configurable() {
+    let cfg = QuicConfig {
+        server_name: "localhost".into(),
+        port: 443,
+    };
+    let mut conn = QuicConnection::new(cfg).unwrap();
+    assert!(!conn.is_zero_copy_enabled());
+    conn.configure_zero_copy(core::ZeroCopyConfig {
+        enable_send: true,
+        enable_recv: false,
+    });
+    assert!(conn.is_zero_copy_enabled());
 }


### PR DESCRIPTION
## Summary
- expose `ZeroCopyConfig` and helpers for enabling zero-copy
- implement a `PathMtuManager` with configurable MTU discovery
- update tests for new API

## Testing
- `cargo test -p core --manifest-path rust/Cargo.toml`
- `cargo test -p integration-tests --manifest-path rust/Cargo.toml` *(fails: could not compile `crypto`)*

------
https://chatgpt.com/codex/tasks/task_e_6864385ca1d083338fd2316e1e7819fc