### PR TITLE
Fix FEC memory buffer handling

### DIFF
--- a/fec/FEC_Modul.cpp
+++ b/fec/FEC_Modul.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cassert>
 #include <thread>
+#include <functional>
 
 // OpenMP for parallel processing
 #ifdef _OPENMP
@@ -657,13 +658,14 @@ std::string FECModule::get_performance_report() const {
     return impl_->get_performance_report();
 }
 
-void* FECModule::allocate_from_pool(size_t size) {
-    // This would use the internal memory pool
-    return nullptr;
-}
-
-void FECModule::deallocate_to_pool(void* ptr, size_t size) {
-    // This would return memory to the internal pool
+FECModule::BufferPtr FECModule::allocate_from_pool(size_t size) {
+    uint8_t* ptr = static_cast<uint8_t*>(impl_->memory_pool_.allocate());
+    auto deleter = [this](uint8_t* p) {
+        if (p) {
+            impl_->memory_pool_.deallocate(p);
+        }
+    };
+    return BufferPtr(ptr, deleter);
 }
 
 std::vector<uint8_t> FECModule::encode(const std::vector<uint8_t>& data) {

--- a/fec/FEC_Modul.hpp
+++ b/fec/FEC_Modul.hpp
@@ -314,8 +314,8 @@ public:
     std::string get_performance_report() const;
     
     // Memory management
-    void* allocate_from_pool(size_t size);
-    void deallocate_to_pool(void* ptr, size_t size);
+    using BufferPtr = std::unique_ptr<uint8_t[], std::function<void(uint8_t*)>>;
+    BufferPtr allocate_from_pool(size_t size);
     
     // Legacy compatibility
     std::vector<uint8_t> encode(const std::vector<uint8_t>& data);


### PR DESCRIPTION
## Summary
- manage buffers with `std::unique_ptr` instead of raw pointers
- remove unused deallocation function

## Testing
- `cmake ..`
- `cmake --build .` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68643fcd20948333a7c39c3bcd659103