### PR TITLE
Add Rust MTU manager enhancements

### DIFF
--- a/rust/tests/tests/path_mtu_manager.rs
+++ b/rust/tests/tests/path_mtu_manager.rs
@@ -1,7 +1,16 @@
-use core::{DEFAULT_MAX_MTU, DEFAULT_MIN_MTU};
+use core::{MtuStatus, PathMtuManager, DEFAULT_MAX_MTU, DEFAULT_MIN_MTU};
 
 #[test]
 fn constants() {
     assert!(DEFAULT_MIN_MTU >= 1200);
     assert!(DEFAULT_MIN_MTU <= DEFAULT_MAX_MTU);
+}
+
+#[test]
+fn reports_status() {
+    let mut mgr = PathMtuManager::new();
+    assert_eq!(mgr.get_mtu_status(false), MtuStatus::Disabled);
+    mgr.update(0.0, 50);
+    assert_eq!(mgr.get_mtu_status(false), MtuStatus::Searching);
+    assert!(mgr.is_mtu_unstable());
 }

--- a/rust/tests/tests/path_mtu_probe_logic.rs
+++ b/rust/tests/tests/path_mtu_probe_logic.rs
@@ -2,7 +2,17 @@ use core::PathMtuManager;
 
 #[test]
 fn has_probe_methods() {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
     let mut mgr = PathMtuManager::new();
+    let flag = Arc::new(AtomicBool::new(false));
+    let flag_clone = flag.clone();
+    mgr.set_mtu_change_callback(move |_| {
+        flag_clone.store(true, Ordering::Relaxed);
+    });
     let id = mgr.send_probe(1200, false);
     mgr.handle_probe_response(id, true, false);
+    assert!(flag.load(Ordering::Relaxed));
 }

--- a/rust/tests/tests/quic_connection.rs
+++ b/rust/tests/tests/quic_connection.rs
@@ -18,9 +18,11 @@ fn zero_copy_configurable() {
     };
     let mut conn = QuicConnection::new(cfg).unwrap();
     assert!(!conn.is_zero_copy_enabled());
-    conn.configure_zero_copy(core::ZeroCopyConfig {
+    let cfg = core::ZeroCopyConfig {
         enable_send: true,
         enable_recv: false,
-    });
+    };
+    conn.configure_zero_copy(cfg);
     assert!(conn.is_zero_copy_enabled());
+    assert_eq!(conn.zero_copy_config(), cfg);
 }


### PR DESCRIPTION
## Summary
- add MTU change events and callback support
- expose MTU status API and update routine
- include zero-copy configuration checks in tests
- expand MTU manager tests with new behaviours

## Testing
- `cargo test -p core --quiet`
- `cargo test -p integration-tests --quiet` *(fails: target feature `avx512f` is unstable)*

------
https://chatgpt.com/codex/tasks/task_e_6864406fa1b08333b1cd51cc19884c12