### PR TITLE
Port legacy CLI stub to Rust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,16 +94,6 @@ add_library(quicfuscate_optimize
 target_include_directories(quicfuscate_optimize PUBLIC ${PROJECT_SOURCE_DIR}/optimize ${PROJECT_SOURCE_DIR}/core)
 
 if(TARGET quicfuscate_core)
-add_executable(quicfuscate_cli cli/quicfuscate_cli.cpp)
-target_link_libraries(quicfuscate_cli PRIVATE
-    quicfuscate_core
-    quicfuscate_crypto
-    quicfuscate_fec
-    quicfuscate_stealth
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    quiche
-)
 
 add_executable(quicfuscate_client cli/quicfuscate_client.cpp)
 target_link_libraries(quicfuscate_client PRIVATE

--- a/cli/quicfuscate_cli.cpp
+++ b/cli/quicfuscate_cli.cpp
@@ -1,9 +1,0 @@
-#include <iostream>
-#include <getopt.h>  // Für CLI-Optionen
-#include "../core/quic.hpp"  // Annahme: Relative Include
-
-int main(int argc, char* argv[]) {
-    std::cout << "QuicFuscate CLI gestartet. Optionen: --host, --port, etc." << std::endl;
-    // Stub für CLI-Logik, z. B. Server starten
-    return 0;
-}

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -20,6 +20,8 @@ fn print_fingerprints() {
 fn main() {
     let opts = CommandLineOptions::parse();
 
+    println!("QuicFuscate CLI gestartet. Optionen: --server/--host, --port, etc.");
+
     if opts.list_fingerprints {
         print_fingerprints();
         return;

--- a/rust/cli/src/options.rs
+++ b/rust/cli/src/options.rs
@@ -17,7 +17,7 @@ pub enum Fingerprint {
 #[command(author, version, about="QuicFuscate VPN - QUIC mit uTLS Integration", long_about=None)]
 pub struct CommandLineOptions {
     /// Server-Hostname oder IP-Adresse
-    #[arg(short, long, default_value = "example.com")]
+    #[arg(short, long, alias = "host", default_value = "example.com")]
     pub server: String,
 
     /// Server-Port

--- a/rust/cli/tests/cli_tests.rs
+++ b/rust/cli/tests/cli_tests.rs
@@ -38,3 +38,14 @@ fn parse_custom_values() -> Result<(), clap::Error> {
     assert!(opts.debug_tls);
     Ok(())
 }
+
+#[test]
+fn host_alias() -> Result<(), clap::Error> {
+    let opts = CommandLineOptions::try_parse_from([
+        "prog",
+        "--host",
+        "example.org",
+    ])?;
+    assert_eq!(opts.server, "example.org");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- extend Rust CLI to output startup message
- add `--host` alias for `--server`
- validate alias in tests
- stop building old C++ CLI in `CMakeLists.txt`
- remove `cli/quicfuscate_cli.cpp`

## Testing
- `cargo test -p quicfuscate-cli`
- `cargo run -p quicfuscate-cli --bin quicfuscate -- --help`

------
https://chatgpt.com/codex/tasks/task_e_68652ea418ac833392c3f296be8eacb5