### PR TITLE
Port FEC to Rust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,11 +68,26 @@ add_library(quicfuscate_crypto
 target_include_directories(quicfuscate_crypto PUBLIC ${PROJECT_SOURCE_DIR}/crypto)
 target_link_libraries(quicfuscate_crypto PUBLIC OpenSSL::SSL OpenSSL::Crypto)
 
-add_library(quicfuscate_fec
-    fec/FEC_Modul.cpp
+
+set(RUST_FEC_LIB "${PROJECT_SOURCE_DIR}/rust/fec/target/release/libfec.a")
+
+if(EXISTS "${PROJECT_SOURCE_DIR}/rust/fec/Cargo.toml")
+add_custom_command(
+    OUTPUT ${RUST_FEC_LIB}
+    COMMAND cargo build --release
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/rust/fec
+    COMMENT "Building Rust FEC via cargo"
 )
 
-target_include_directories(quicfuscate_fec PUBLIC ${PROJECT_SOURCE_DIR}/fec)
+add_custom_target(rust_fec_build ALL DEPENDS ${RUST_FEC_LIB})
+
+add_library(quicfuscate_fec STATIC IMPORTED GLOBAL)
+set_target_properties(quicfuscate_fec PROPERTIES
+    IMPORTED_LOCATION "${RUST_FEC_LIB}"
+    INTERFACE_INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/fec"
+)
+add_dependencies(quicfuscate_fec rust_fec_build)
+endif()
 
 add_library(quicfuscate_stealth
     stealth/DoH.cpp

--- a/rust/tests/tests/fec_module.rs
+++ b/rust/tests/tests/fec_module.rs
@@ -1,17 +1,18 @@
 use fec::{
-    fec_module_cleanup_stub as fec_module_cleanup,
-    fec_module_decode_stub as fec_module_decode,
-    fec_module_encode_stub as fec_module_encode,
-    fec_module_init_stub as fec_module_init,
+    fec_module_cleanup, fec_module_decode, fec_module_encode, fec_module_init,
 };
 
 #[test]
 fn encode_decode() {
     assert_eq!(0, fec_module_init());
     let msg = b"hello";
-    let enc = fec_module_encode(msg);
-    assert!(!enc.is_empty());
-    let dec = fec_module_decode(&enc);
+    let mut enc_len = 0usize;
+    let enc_ptr = fec_module_encode(msg.as_ptr(), msg.len(), &mut enc_len as *mut usize);
+    assert!(!enc_ptr.is_null());
+    let enc = unsafe { Vec::from_raw_parts(enc_ptr, enc_len, enc_len) };
+    let mut dec_len = 0usize;
+    let dec_ptr = fec_module_decode(enc.as_ptr(), enc.len(), &mut dec_len as *mut usize);
+    let dec = unsafe { Vec::from_raw_parts(dec_ptr, dec_len, dec_len) };
     fec_module_cleanup();
     assert_eq!(dec, msg);
 }


### PR DESCRIPTION
## Summary
- implement GF-based repair packet generation in Rust FEC module
- build the Rust FEC crate from CMake instead of the old C++ code
- update Rust integration test to use the real FFI API

## Testing
- `cargo test -p fec --quiet`
- `cargo test -p integration-tests --quiet` *(fails: `crypto` crate requires nightly features)*

------
https://chatgpt.com/codex/tasks/task_e_68656c23a19c8333bc503261d9a902a5