### PR TITLE
Implement stealth engine features

### DIFF
--- a/rust/stealth/src/spinbit.rs
+++ b/rust/stealth/src/spinbit.rs
@@ -36,4 +36,12 @@ mod tests {
         assert!(!r.randomize(true));
         assert!(r.randomize(false));
     }
+
+    #[test]
+    fn never_flip_when_probability_zero() {
+        let mut r = SpinBitRandomizer::new();
+        r.set_probability(0.0);
+        assert!(r.randomize(true));
+        assert!(!r.randomize(false));
+    }
 }

--- a/rust/stealth/src/zero_rtt.rs
+++ b/rust/stealth/src/zero_rtt.rs
@@ -16,9 +16,16 @@ impl ZeroRttEngine {
     pub async fn send_early_data(&mut self, data: &[u8]) -> Result<(), ()> {
         self.attempts += 1;
 
+        // Mirror the checks performed by the C++ implementation. Early data
+        // can only be sent when zero-RTT has been enabled and the payload size
+        // stays within the configured limit.
         if !self.enabled || data.len() > MAX_EARLY_DATA_SIZE {
             return Err(());
         }
+
+        // In the C++ version the data would be written to the network. Here we
+        // simply simulate a small asynchronous delay so the call truly awaits.
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
         self.successes += 1;
         Ok(())

--- a/rust/tests/tests/xor_obfuscation.rs
+++ b/rust/tests/tests/xor_obfuscation.rs
@@ -9,3 +9,11 @@ fn encode_decode_roundtrip() {
     let decoded = obf.deobfuscate(&encoded, XORPattern::Simple);
     assert_eq!(decoded, data);
 }
+
+#[test]
+fn obfuscation_flips_bits() {
+    let mut obf = XORObfuscator::new();
+    let data = [0xFFu8];
+    let encoded = obf.obfuscate(&data, XORPattern::Simple);
+    assert_eq!(encoded, vec![0x55]);
+}


### PR DESCRIPTION
## Summary
- flesh out ZeroRttEngine::send_early_data
- add simple bundling logic to DatagramEngine
- allow StreamEngine to close streams and report count
- extend spin bit and XOR tests

## Testing
- `cargo test -p stealth --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68657b41bfbc83339ee4b0bc1f0bad16