### PR TITLE
Improve Rust integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Build Rust workspace
         run: |
           cargo build --manifest-path rust/Cargo.toml --workspace --release
+      - name: Test Rust workspace
+        run: |
+          cargo test --manifest-path rust/Cargo.toml --workspace --all-targets
       - name: Configure
         run: |
           mkdir build && cd build

--- a/rust/tests/tests/aegis128l.rs
+++ b/rust/tests/tests/aegis128l.rs
@@ -17,3 +17,21 @@ fn encrypt_decrypt_roundtrip() {
         .is_ok());
     assert_eq!(decrypted, msg);
 }
+
+#[test]
+fn decrypt_fails_with_wrong_tag() {
+    let cipher = Aegis128L::new();
+    let msg = b"tamper";
+    let key = [0u8; Aegis128L::KEY_SIZE];
+    let nonce = [0u8; Aegis128L::NONCE_SIZE];
+    let mut ciphertext = Vec::new();
+    let mut tag = [0u8; Aegis128L::TAG_SIZE];
+
+    let _ = cipher.encrypt(msg, &key, &nonce, &[], &mut ciphertext, &mut tag);
+    tag[0] ^= 0xFF;
+
+    let mut decrypted = Vec::new();
+    assert!(cipher
+        .decrypt(&ciphertext, &key, &nonce, &[], &tag, &mut decrypted)
+        .is_err());
+}

--- a/rust/tests/tests/browser_fingerprinting.rs
+++ b/rust/tests/tests/browser_fingerprinting.rs
@@ -1,8 +1,17 @@
-use stealth::{BrowserFingerprint, BrowserType, OperatingSystem};
+use stealth::{
+    browser::{default_headers, BrowserProfile},
+    BrowserFingerprint, BrowserType, OperatingSystem,
+};
 
 #[test]
 fn headers_include_user_agent() {
     let fp = BrowserFingerprint::new(BrowserType::Chrome, OperatingSystem::Windows, "UA".into());
     let headers = fp.generate_http_headers();
     assert_eq!(headers.get("User-Agent"), Some(&"UA".to_string()));
+}
+
+#[test]
+fn default_profiles_provide_user_agent() {
+    let headers = default_headers(BrowserProfile::Firefox);
+    assert!(headers.get("user-agent").is_some());
 }

--- a/rust/tests/tests/fec_module.rs
+++ b/rust/tests/tests/fec_module.rs
@@ -1,5 +1,6 @@
 use fec::{
     fec_module_cleanup, fec_module_decode, fec_module_encode, fec_module_init,
+    FECConfig, FECModule, FECPacket,
 };
 
 #[test]
@@ -15,4 +16,16 @@ fn encode_decode() {
     let dec = unsafe { Vec::from_raw_parts(dec_ptr, dec_len, dec_len) };
     fec_module_cleanup();
     assert_eq!(dec, msg);
+}
+
+#[test]
+fn decode_returns_empty_without_source_packet() {
+    let module = FECModule::new(FECConfig::default());
+    let repair = FECPacket {
+        sequence_number: 1,
+        is_repair: true,
+        data: vec![1, 2, 3],
+    };
+    let result = module.decode(&[repair]).unwrap();
+    assert!(result.is_empty());
 }

--- a/rust/tests/tests/path_mtu_manager.rs
+++ b/rust/tests/tests/path_mtu_manager.rs
@@ -31,3 +31,12 @@ fn mtu_probe_and_blackhole() {
     }
     assert_eq!(mgr.get_mtu_status(false), MtuStatus::Blackhole);
 }
+
+#[test]
+fn high_loss_reduces_mtu() {
+    let mut mgr = PathMtuManager::new();
+    mgr.set_mtu_size(DEFAULT_MAX_MTU, false);
+    let before = mgr.get_outgoing_mtu();
+    mgr.update(0.5, 150);
+    assert!(mgr.get_outgoing_mtu() < before);
+}


### PR DESCRIPTION
## Summary
- extend coverage in `rust/tests` for crypto, stealth, FEC and MTU logic
- add a cargo test step to the CI workflow

## Testing
- `RUSTC_BOOTSTRAP=1 cargo test --manifest-path rust/Cargo.toml --workspace --all-targets` *(fails: target feature `avx512f` is unstable)*

------
https://chatgpt.com/codex/tasks/task_e_68662fc1e350833388b4b268689a438f