### PR TITLE
Remove unwrap from FEC test

### DIFF
--- a/rust/tests/tests/fec_module.rs
+++ b/rust/tests/tests/fec_module.rs
@@ -26,6 +26,9 @@ fn decode_returns_empty_without_source_packet() {
         is_repair: true,
         data: vec![1, 2, 3],
     };
-    let result = module.decode(&[repair]).unwrap();
+    let result = match module.decode(&[repair]) {
+        Ok(data) => data,
+        Err(e) => panic!("decode failed: {:?}", e),
+    };
     assert!(result.is_empty());
 }


### PR DESCRIPTION
## Summary
- replace `unwrap()` in `fec_module` integration test with match-based error handling

## Testing
- `cargo test` *(fails: could not compile `crypto` integration tests due to private `CryptoError` enum)*

------
https://chatgpt.com/codex/tasks/task_e_68665eaef32c833383513e64ab63fc86