### PR TITLE
Expand integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cargo test --manifest-path rust/Cargo.toml --workspace --all-targets
       - name: Run integration tests
         run: |
-          cargo test --manifest-path rust/tests/Cargo.toml
+          cargo test --manifest-path rust/tests/Cargo.toml --all-targets
       - name: Configure
         run: |
           mkdir build && cd build

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "crypto",
  "fec",
  "stealth",
+ "tokio",
 ]
 
 [[package]]

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -8,3 +8,4 @@ core = { path = "../core" }
 crypto = { path = "../crypto" }
 fec = { path = "../fec" }
 stealth = { path = "../stealth" }
+tokio = { version = "1", features = ["rt", "macros"] }

--- a/rust/tests/tests/datagram_bundling.rs
+++ b/rust/tests/tests/datagram_bundling.rs
@@ -1,0 +1,29 @@
+use stealth::datagram::DatagramEngine;
+use tokio::runtime::Runtime;
+
+#[test]
+fn bundling_flushes_after_queue_limit() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut eng = DatagramEngine::new();
+        eng.enable_bundling(true);
+        for i in 0..11 {
+            eng.send(vec![i as u8], 1);
+        }
+        // sending more than the internal limit should trigger a flush
+        assert!(eng.recv().await.is_some());
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn recv_returns_none_when_empty() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut eng = DatagramEngine::new();
+        assert_eq!(eng.recv().await, None);
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}

--- a/rust/tests/tests/invalid_inputs.rs
+++ b/rust/tests/tests/invalid_inputs.rs
@@ -1,0 +1,24 @@
+use fec::{FECModule, FECConfig};
+use stealth::stream::{StreamEngine, StreamError};
+use tokio::runtime::Runtime;
+
+#[test]
+fn fec_decode_empty_slice() {
+    let module = FECModule::new(FECConfig::default());
+    let result = module.decode(&[]).expect("decode should succeed");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn stream_recv_no_data() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut engine = StreamEngine::new();
+        match engine.recv().await {
+            Err(StreamError::NoData) => (),
+            other => panic!("unexpected result: {:?}", other),
+        }
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add datagram engine bundling tests
- add FEC and stream error handling tests for invalid inputs
- install tokio dependency for integration tests
- run integration tests with all targets in CI

## Testing
- `RUSTC_BOOTSTRAP=1 cargo test --manifest-path rust/Cargo.toml --workspace --all-targets`
- `RUSTC_BOOTSTRAP=1 cargo test --manifest-path rust/tests/Cargo.toml --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_686661ae87f08333878899a059e5a4fb