### PR TITLE
Add FEC module free tests

### DIFF
--- a/rust/fec/src/lib.rs
+++ b/rust/fec/src/lib.rs
@@ -350,6 +350,13 @@ pub extern "C" fn fec_module_get_statistics(buf: *mut StatFFI) -> i32 {
     -1
 }
 
+#[no_mangle]
+pub extern "C" fn fec_module_free(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() && len > 0 {
+        unsafe { let _ = Vec::from_raw_parts(ptr, len, len); }
+    }
+}
+
 pub fn fec_module_init_stub() -> i32 {
     0
 }
@@ -363,6 +370,8 @@ pub fn fec_module_encode_stub(data: &[u8]) -> Vec<u8> {
 pub fn fec_module_decode_stub(data: &[u8]) -> Vec<u8> {
     data.to_vec()
 }
+
+pub fn fec_module_free_stub(_ptr: *mut u8, _len: usize) {}
 
 #[cfg(test)]
 mod tests {

--- a/rust/tests/tests/fec_module_free.rs
+++ b/rust/tests/tests/fec_module_free.rs
@@ -1,0 +1,18 @@
+use fec::{fec_module_encode, fec_module_decode, fec_module_init, fec_module_cleanup, fec_module_free};
+
+#[test]
+fn encode_decode_loop_with_free() {
+    assert_eq!(0, fec_module_init());
+    for _ in 0..100 {
+        let msg = b"hello";
+        let mut enc_len = 0usize;
+        let enc_ptr = fec_module_encode(msg.as_ptr(), msg.len(), &mut enc_len as *mut usize);
+        assert!(!enc_ptr.is_null());
+        let mut dec_len = 0usize;
+        let dec_ptr = fec_module_decode(enc_ptr, enc_len, &mut dec_len as *mut usize);
+        assert!(!dec_ptr.is_null());
+        fec_module_free(enc_ptr, enc_len);
+        fec_module_free(dec_ptr, dec_len);
+    }
+    fec_module_cleanup();
+}


### PR DESCRIPTION
## Summary
- expose `fec_module_free` in the `fec` crate
- add stub `fec_module_free_stub`
- add integration test `fec_module_free`

## Testing
- `cargo +nightly test --manifest-path rust/tests/Cargo.toml`
- `valgrind --leak-check=full cargo +nightly test --test fec_module_free --manifest-path rust/tests/Cargo.toml`
- `RUSTFLAGS="-Z sanitizer=address" cargo +nightly test --test fec_module_free --manifest-path rust/tests/Cargo.toml` *(fails: can't find crate for tokio_macros)*

------
https://chatgpt.com/codex/tasks/task_e_68666841fdd08333b8d98f0f7e92ab54