### PR TITLE
Update FEC and stealth documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,17 @@ because all crates have been consolidated under `rust/`.
 ### ⚡ Performance Optimizations
 - **SIMD Acceleration**: ARM NEON and x86 AVX2/AVX-512 optimizations
 - **Zero-Copy Architecture**: Minimizes memory allocations for maximum throughput
-- **Adaptive FEC**: TETRYS-based Forward Error Correction with dynamic redundancy
+- **Experimental FEC**: Early TETRYS-based Forward Error Correction module
 - **Connection Multiplexing**: Multiple streams over a single connection
 - **0-RTT Handshake**: Reduced latency for subsequent connections
 
 ### 🔄 Adaptive Error Correction
-- **TETRYS FEC Implementation**: Advanced coding scheme for lossy networks
-- **Dynamic Redundancy**: Automatically adjusts to network conditions
-- **Packet Recovery**: Up to 30% packet loss tolerance
-- **Bandwidth-Efficient**: Minimal overhead compared to traditional FEC
+- **TETRYS FEC (experimental)**: Basic encoder/decoder implementation
+- **Dynamic Redundancy (planned)**: Automatic adjustments to network conditions
+- **Packet Recovery**: Initial support for lossy networks
+- **Bandwidth-Efficient**: Aims for minimal overhead compared to traditional FEC
+
+> **Note:** The FEC and Stealth modules are experimental and not yet production ready.
 
 ## 🏗️ Project Status
 
@@ -76,8 +78,8 @@ This project is currently being refactored from C++ to Rust to leverage modern l
 | Transport Protocol  | QUIC v1 / HTTP/3                   |
 | Encryption         | AEGIS-128L/X, MORUS-1280-128       |
 | Key Exchange       | X25519, X448                       |
-| Error Correction   | TETRYS FEC                         |
-| Obfuscation       | XOR-based, Traffic Shaping, Fake TLS |
+| Error Correction   | TETRYS FEC (experimental)           |
+| Obfuscation       | XOR-based, Traffic Shaping, Fake TLS (experimental) |
 | Platforms          | Linux, macOS, Windows (planned)     |
 | Architecture       | x86_64, ARM64                      |
 | Performance        | Multi-Gigabit capable              |

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ This directory contains documentation for the Rust reimplementation of **QuicFus
 original C++ code base is documented in [`DOCUMENTATION.md`](DOCUMENTATION.md).
 The Rust modules mirror the same high level design while taking advantage of
 Rust's safety guarantees and build tooling. The `core`, `crypto`, `fec` and
-`stealth` crates have reached feature parity with their original C++
-counterparts, and further work continues in Rust only.
-The legacy C++ modules are deprecated and kept only for reference.
+`stealth` crates are being ported from C++ and have not yet reached full
+feature parity. Further work continues in Rust only. The legacy C++ modules are
+deprecated and kept only for reference.
 
 > **Note:** Only one Rust workspace exists. All crates reside under the `rust/`
 directory and there is no separate `Rust-QuicFuscate` folder.
@@ -28,17 +28,19 @@ code reuses the same concepts of AEGIS‑128X/L and MORUS‑1280‑128 with a
 `CipherSuiteSelector` to pick the optimal cipher based on CPU features.
 
 ### FEC Crate
-The Forward Error Correction crate now provides stable encoder and decoder
-implementations and supersedes the old C++ implementation. It offers adaptive
-redundancy with memory-pooled buffers, and SIMD optimised Galois field
-arithmetic continues to be developed as described in the original
-documentation【F:docs/DOCUMENTATION.md†L173-L202】.
+The Forward Error Correction crate currently offers a basic encoder and decoder
+and is intended to replace the old C++ implementation. Adaptive redundancy with
+memory-pooled buffers and SIMD optimised Galois field arithmetic are still in
+development as described in the original
+documentation【F:docs/DOCUMENTATION.md†L173-L202】. The module is experimental
+and not yet production ready.
 
 ### Stealth Crate
 Traffic obfuscation is handled by the `stealth` crate.  Basic XOR obfuscation,
 DoH tunnelling and domain fronting are already functional.  uTLS
 fingerprinting and HTTP/3 masquerading are in active development as outlined in
 the *Stealth Module* section of the C++ documentation【F:docs/DOCUMENTATION.md†L1888-L1905】.
+Like the FEC crate, this module is considered experimental and not production ready.
 
 ## Building & Testing the Rust Workspace
 First build the patched `quiche` submodule, then compile and test the Rust workspace:


### PR DESCRIPTION
## Summary
- update docs/README about feature parity and module status
- clarify in README that FEC and stealth are experimental
- adjust FEC bullet points and table entries accordingly

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6866683fd2708333ba750c492fe00fe6