### PR TITLE
Remove duplicate FFI free function

### DIFF
--- a/rust/fec/src/lib.rs
+++ b/rust/fec/src/lib.rs
@@ -440,12 +440,6 @@ pub extern "C" fn fec_module_get_statistics(buf: *mut StatFFI) -> i32 {
     -1
 }
 
-#[no_mangle]
-pub extern "C" fn fec_module_free(ptr: *mut u8, len: usize) {
-    if !ptr.is_null() && len > 0 {
-        unsafe { let _ = Vec::from_raw_parts(ptr, len, len); }
-    }
-}
 
 pub fn fec_module_init_stub() -> i32 {
     0


### PR DESCRIPTION
## Summary
- remove redundant `fec_module_free` definition in `rust/fec/src/lib.rs`

## Testing
- `cargo test --workspace` *(fails: `E0554` unstable feature)*

------
https://chatgpt.com/codex/tasks/task_e_68651891efc48333bfc570e05b724fd5