### PR TITLE
Add configurable stealth features

### DIFF
--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -59,7 +59,12 @@ fn main() {
         FecCliMode::Adaptive => println!("FEC adaptive with target latency {} ms", opts.fec_ratio),
     }
 
-    let stealth = QuicFuscateStealth::new();
+    let mut stealth = QuicFuscateStealth::new();
+    stealth.enable_domain_fronting(opts.domain_fronting);
+    stealth.enable_http3_masq(opts.http3_masq);
+    stealth.enable_doh(opts.doh);
+    stealth.enable_spinbit(opts.spin_random);
+    stealth.enable_zero_rtt(opts.zero_rtt);
     if stealth.initialize() {
         println!("Stealth subsystem initialized.");
     } else {

--- a/rust/cli/src/options.rs
+++ b/rust/cli/src/options.rs
@@ -79,4 +79,24 @@ pub struct CommandLineOptions {
     /// Zeigt verfügbare Browser-Fingerprints an
     #[arg(long)]
     pub list_fingerprints: bool,
+
+    /// Enable domain fronting
+    #[arg(long, default_value_t = false)]
+    pub domain_fronting: bool,
+
+    /// Enable HTTP/3 masquerading
+    #[arg(long, default_value_t = false)]
+    pub http3_masq: bool,
+
+    /// Enable DNS over HTTPS
+    #[arg(long, default_value_t = false)]
+    pub doh: bool,
+
+    /// Enable spinbit randomization
+    #[arg(long, default_value_t = false)]
+    pub spin_random: bool,
+
+    /// Enable Zero-RTT data
+    #[arg(long, default_value_t = false)]
+    pub zero_rtt: bool,
 }

--- a/rust/stealth/src/browser.rs
+++ b/rust/stealth/src/browser.rs
@@ -24,17 +24,52 @@ pub enum BrowserProfile {
     Edge,
 }
 
+/// Minimal TLS handshake fingerprint used for uTLS emulation.
+#[derive(Clone)]
+pub struct TlsFingerprint {
+    pub cipher_suites: Vec<u16>,
+    pub extensions: Vec<u16>,
+    pub alpn: Vec<String>,
+}
+
+impl Default for TlsFingerprint {
+    fn default() -> Self {
+        Self {
+            cipher_suites: vec![0x1301, 0x1302, 0x1303],
+            extensions: vec![0x000a, 0x000b],
+            alpn: vec!["h3".into(), "http/1.1".into()],
+        }
+    }
+}
+
 /// Simplified representation of a browser fingerprint used for
 /// HTTP header generation and TLS emulation.
 pub struct BrowserFingerprint {
     pub browser: BrowserType,
     pub os: OperatingSystem,
     pub user_agent: String,
+    pub tls: TlsFingerprint,
 }
 
 impl BrowserFingerprint {
     pub fn new(browser: BrowserType, os: OperatingSystem, user_agent: String) -> Self {
-        Self { browser, os, user_agent }
+        Self { browser, os, user_agent, tls: TlsFingerprint::default() }
+    }
+
+    /// Create a fingerprint from a predefined browser profile.
+    pub fn for_profile(profile: BrowserProfile) -> Self {
+        let (browser, ua) = match profile {
+            BrowserProfile::Chrome => (BrowserType::Chrome, "Mozilla/5.0 Chrome"),
+            BrowserProfile::Firefox => (BrowserType::Firefox, "Mozilla/5.0 Firefox"),
+            BrowserProfile::Safari => (BrowserType::Safari, "Mozilla/5.0 Safari"),
+            BrowserProfile::Edge => (BrowserType::Edge, "Mozilla/5.0 Edge"),
+        };
+        Self {
+            browser,
+            os: OperatingSystem::Windows,
+            user_agent: ua.into(),
+            tls: TlsFingerprint::default(),
+        }
     }
 
     /// Generate a small set of HTTP headers matching the fingerprint.

--- a/rust/stealth/src/doh.rs
+++ b/rust/stealth/src/doh.rs
@@ -15,15 +15,21 @@ impl Default for DohConfig {
 pub struct DohClient {
     config: DohConfig,
     cache: HashMap<String, IpAddr>,
+    enabled: bool,
 }
 
 impl DohClient {
     pub fn new(config: DohConfig) -> Self {
-        Self { config, cache: HashMap::new() }
+        Self { config, cache: HashMap::new(), enabled: false }
     }
+
+    pub fn enable(&mut self, enable: bool) { self.enabled = enable; }
 
     /// Simplified asynchronous resolver that returns a fixed IP address.
     pub async fn resolve(&mut self, domain: &str) -> IpAddr {
+        if !self.enabled {
+            return IpAddr::V4(Ipv4Addr::new(127,0,0,1));
+        }
         if self.config.enable_caching {
             if let Some(ip) = self.cache.get(domain) {
                 return *ip;

--- a/rust/stealth/src/domain_fronting.rs
+++ b/rust/stealth/src/domain_fronting.rs
@@ -14,16 +14,23 @@ impl Default for SniConfig {
 
 pub struct SniHiding {
     config: SniConfig,
+    enabled: bool,
 }
 
 impl SniHiding {
-    pub fn new(config: SniConfig) -> Self { Self { config } }
+    pub fn new(config: SniConfig) -> Self { Self { config, enabled: false } }
+
+    pub fn enable(&mut self, enable: bool) { self.enabled = enable; }
 
     /// Replace the Host header with the fronting domain.
     pub fn apply_domain_fronting(&self, headers: &str) -> String {
-        headers.replace(
-            &format!("Host: {}", self.config.real_domain),
-            &format!("Host: {}", self.config.front_domain),
-        )
+        if !self.enabled {
+            headers.to_string()
+        } else {
+            headers.replace(
+                &format!("Host: {}", self.config.real_domain),
+                &format!("Host: {}", self.config.front_domain),
+            )
+        }
     }
 }

--- a/rust/stealth/src/fake_tls.rs
+++ b/rust/stealth/src/fake_tls.rs
@@ -1,15 +1,28 @@
-use crate::browser::BrowserProfile;
+use crate::browser::{BrowserProfile, TlsFingerprint};
 
 pub struct FakeTls {
     profile: BrowserProfile,
+    fingerprint: TlsFingerprint,
 }
 
 impl FakeTls {
-    pub fn new(profile: BrowserProfile) -> Self { Self { profile } }
+    pub fn new(profile: BrowserProfile) -> Self {
+        Self { profile, fingerprint: TlsFingerprint::default() }
+    }
+
+    pub fn set_profile(&mut self, profile: BrowserProfile) {
+        self.profile = profile;
+        self.fingerprint = TlsFingerprint::default();
+    }
 
     /// Generate a minimal fake TLS ClientHello packet.
     pub fn generate_client_hello(&self) -> Vec<u8> {
-        // This is purely illustrative and not a real TLS handshake.
-        vec![0x16, 0x03, 0x01, 0x00, 0x2a]
+        // Build a fake handshake including cipher suite and extension count.
+        let mut hello = vec![0x16, 0x03, 0x01];
+        hello.push(self.fingerprint.cipher_suites.len() as u8);
+        for cs in &self.fingerprint.cipher_suites {
+            hello.extend_from_slice(&cs.to_be_bytes());
+        }
+        hello
     }
 }

--- a/rust/stealth/src/http3_masq.rs
+++ b/rust/stealth/src/http3_masq.rs
@@ -3,12 +3,19 @@ use std::collections::HashMap;
 
 pub struct Masquerade {
     profile: BrowserProfile,
+    enabled: bool,
 }
 
 impl Masquerade {
-    pub fn new(profile: BrowserProfile) -> Self { Self { profile } }
+    pub fn new(profile: BrowserProfile) -> Self { Self { profile, enabled: false } }
+
+    pub fn enable(&mut self, enable: bool) { self.enabled = enable; }
 
     pub fn headers(&self) -> HashMap<String, String> {
-        default_headers(self.profile)
+        if self.enabled {
+            default_headers(self.profile)
+        } else {
+            HashMap::new()
+        }
     }
 }

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -17,6 +17,10 @@ use spinbit::SpinBitRandomizer;
 use stream::StreamEngine;
 pub use xor::{XORConfig, XORObfuscator, XORPattern};
 use zero_rtt::ZeroRttEngine;
+use domain_fronting::{SniConfig, SniHiding};
+use doh::{DohClient, DohConfig};
+use http3_masq::Masquerade;
+use fake_tls::FakeTls;
 
 pub struct QuicFuscateStealth {
     pub qpack: QpackEngine,
@@ -24,6 +28,10 @@ pub struct QuicFuscateStealth {
     pub datagram: DatagramEngine,
     pub stream: StreamEngine,
     pub spin: SpinBitRandomizer,
+    pub domain_fronting: SniHiding,
+    pub http3_masq: Masquerade,
+    pub doh: DohClient,
+    pub tls: FakeTls,
 }
 
 impl QuicFuscateStealth {
@@ -34,6 +42,10 @@ impl QuicFuscateStealth {
             datagram: DatagramEngine::new(),
             stream: StreamEngine::new(),
             spin: SpinBitRandomizer::new(),
+            domain_fronting: SniHiding::new(SniConfig::default()),
+            http3_masq: Masquerade::new(BrowserProfile::Chrome),
+            doh: DohClient::new(DohConfig::default()),
+            tls: FakeTls::new(BrowserProfile::Chrome),
         }
     }
 
@@ -45,5 +57,21 @@ impl QuicFuscateStealth {
 
     pub fn randomize_spinbit(&self, bit: bool) -> bool {
         self.spin.randomize(bit)
+    }
+
+    pub fn enable_spinbit(&mut self, e: bool) { self.spin.enable(e); }
+    pub fn enable_domain_fronting(&mut self, e: bool) { self.domain_fronting.enable(e); }
+    pub fn enable_http3_masq(&mut self, e: bool) { self.http3_masq.enable(e); }
+    pub fn enable_doh(&mut self, e: bool) { self.doh.enable(e); }
+    pub fn enable_zero_rtt(&mut self, e: bool) { self.zero_rtt.set_enabled(e); }
+
+    pub async fn resolve_domain(&mut self, domain: &str) -> std::net::IpAddr {
+        self.doh.resolve(domain).await
+    }
+
+    pub fn generate_client_hello(&self) -> Vec<u8> { self.tls.generate_client_hello() }
+
+    pub fn apply_domain_fronting(&self, headers: &str) -> String {
+        self.domain_fronting.apply_domain_fronting(headers)
     }
 }

--- a/rust/stealth/src/spinbit.rs
+++ b/rust/stealth/src/spinbit.rs
@@ -12,6 +12,8 @@ impl SpinBitRandomizer {
 
     pub fn set_probability(&mut self, p: f64) { self.probability = p; }
 
+    pub fn enable(&mut self, e: bool) { self.enabled = e; }
+
     pub fn randomize(&self, bit: bool) -> bool {
         if !self.enabled { return bit; }
         let flip = rand::thread_rng().gen_bool(self.probability);

--- a/rust/tests/tests/stealth_full.rs
+++ b/rust/tests/tests/stealth_full.rs
@@ -1,0 +1,20 @@
+use stealth::QuicFuscateStealth;
+use tokio::runtime::Runtime;
+
+#[test]
+fn domain_fronting_and_doh() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut s = QuicFuscateStealth::new();
+        s.enable_domain_fronting(true);
+        s.enable_doh(true);
+        let headers = "Host: real.example.com";
+        let df = s.apply_domain_fronting(headers);
+        assert!(df.contains("front.example.com"));
+        let ip = s.resolve_domain("example.com").await;
+        assert_eq!(ip.to_string(), "93.184.216.34");
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- expand browser fingerprinting with TLS fields
- add toggles for HTTP/3 masquerading, domain fronting and DoH
- support Zero-RTT configuration and spinbit enable flag
- expose stealth options via CLI
- add integration test for domain fronting and DoH

## Testing
- `cargo test --workspace --all-targets`

------
https://chatgpt.com/codex/tasks/task_e_6866ddd18ec88333ac389ed9c83c2cd2