### PR TITLE
Improve stealth features

### DIFF
--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -1,8 +1,8 @@
 mod options;
 use clap::Parser;
 use options::{CommandLineOptions, Fingerprint, FecCliMode};
-use core as quic_core; // dummy use, kann entfernt werden, falls nicht gebraucht
-use stealth::QuicFuscateStealth;
+use core as quic_core; // dummy use
+use stealth::{QuicFuscateStealth, BrowserProfile};
 use env_logger::Env;
 use log::info;
 
@@ -63,6 +63,10 @@ fn main() {
     }
 
     let mut stealth = QuicFuscateStealth::new();
+    stealth.set_browser_profile(BrowserProfile::from(opts.fingerprint));
+    stealth.enable_utls(!opts.no_utls);
+    stealth.set_spinbit_probability(opts.spin_probability);
+    stealth.set_zero_rtt_max_early_data(opts.zero_rtt_max);
     stealth.enable_domain_fronting(opts.domain_fronting);
     stealth.enable_http3_masq(opts.http3_masq);
     stealth.enable_doh(opts.doh);

--- a/rust/cli/src/options.rs
+++ b/rust/cli/src/options.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueEnum};
-use fec::{FecMode};
+use fec::FecMode;
+use stealth::BrowserProfile;
 
 #[derive(Copy, Clone, PartialEq, Eq, ValueEnum, Debug)]
 pub enum FecCliMode {
@@ -31,6 +32,18 @@ pub enum Fingerprint {
     ChromeAndroid,
     SafariIos,
     Random,
+}
+
+impl From<Fingerprint> for BrowserProfile {
+    fn from(fp: Fingerprint) -> Self {
+        match fp {
+            Fingerprint::Chrome | Fingerprint::Brave | Fingerprint::Opera | Fingerprint::ChromeAndroid => BrowserProfile::Chrome,
+            Fingerprint::Firefox => BrowserProfile::Firefox,
+            Fingerprint::Safari | Fingerprint::SafariIos => BrowserProfile::Safari,
+            Fingerprint::Edge => BrowserProfile::Edge,
+            Fingerprint::Random => BrowserProfile::Chrome,
+        }
+    }
 }
 
 #[derive(Parser, Debug)]
@@ -96,7 +109,15 @@ pub struct CommandLineOptions {
     #[arg(long, default_value_t = false)]
     pub spin_random: bool,
 
+    /// Probability for spinbit flipping
+    #[arg(long, default_value_t = 0.5)]
+    pub spin_probability: f64,
+
     /// Enable Zero-RTT data
     #[arg(long, default_value_t = false)]
     pub zero_rtt: bool,
+
+    /// Maximum bytes allowed for Zero-RTT data
+    #[arg(long, default_value_t = 1024)]
+    pub zero_rtt_max: usize,
 }

--- a/rust/stealth/src/browser.rs
+++ b/rust/stealth/src/browser.rs
@@ -42,6 +42,37 @@ impl Default for TlsFingerprint {
     }
 }
 
+impl TlsFingerprint {
+    /// Create a fingerprint resembling a real browser profile. The values are
+    /// simplified and do not represent the full set of extensions a modern
+    /// browser would send, but they allow tests to validate profile specific
+    /// behaviour.
+    pub fn for_profile(profile: BrowserProfile) -> Self {
+        match profile {
+            BrowserProfile::Chrome => Self {
+                cipher_suites: vec![0x1301, 0x1302, 0x1303, 0x1304],
+                extensions: vec![0x000a, 0x000b, 0x002d],
+                alpn: vec!["h3".into(), "h2".into(), "http/1.1".into()],
+            },
+            BrowserProfile::Firefox => Self {
+                cipher_suites: vec![0x1301, 0x1302, 0x1303],
+                extensions: vec![0x000a, 0x0010, 0x002b],
+                alpn: vec!["h3".into(), "http/1.1".into()],
+            },
+            BrowserProfile::Safari => Self {
+                cipher_suites: vec![0x1301, 0x1302],
+                extensions: vec![0x000a, 0x0017],
+                alpn: vec!["h3".into(), "h2".into(), "http/1.1".into()],
+            },
+            BrowserProfile::Edge => Self {
+                cipher_suites: vec![0x1301, 0x1302, 0x1303],
+                extensions: vec![0x000a, 0x000b, 0x0010],
+                alpn: vec!["h3".into(), "http/1.1".into()],
+            },
+        }
+    }
+}
+
 /// Simplified representation of a browser fingerprint used for
 /// HTTP header generation and TLS emulation.
 pub struct BrowserFingerprint {
@@ -68,7 +99,7 @@ impl BrowserFingerprint {
             browser,
             os: OperatingSystem::Windows,
             user_agent: ua.into(),
-            tls: TlsFingerprint::default(),
+            tls: TlsFingerprint::for_profile(profile),
         }
     }
 

--- a/rust/stealth/src/fake_tls.rs
+++ b/rust/stealth/src/fake_tls.rs
@@ -3,20 +3,30 @@ use crate::browser::{BrowserProfile, TlsFingerprint};
 pub struct FakeTls {
     profile: BrowserProfile,
     fingerprint: TlsFingerprint,
+    enabled: bool,
 }
 
 impl FakeTls {
     pub fn new(profile: BrowserProfile) -> Self {
-        Self { profile, fingerprint: TlsFingerprint::default() }
+        Self {
+            profile,
+            fingerprint: TlsFingerprint::for_profile(profile),
+            enabled: true,
+        }
     }
 
     pub fn set_profile(&mut self, profile: BrowserProfile) {
         self.profile = profile;
-        self.fingerprint = TlsFingerprint::default();
+        self.fingerprint = TlsFingerprint::for_profile(profile);
     }
+
+    pub fn enable(&mut self, e: bool) { self.enabled = e; }
 
     /// Generate a minimal fake TLS ClientHello packet.
     pub fn generate_client_hello(&self) -> Vec<u8> {
+        if !self.enabled {
+            return Vec::new();
+        }
         // Build a fake handshake including cipher suite and extension count.
         let mut hello = vec![0x16, 0x03, 0x01];
         hello.push(self.fingerprint.cipher_suites.len() as u8);

--- a/rust/stealth/src/http3_masq.rs
+++ b/rust/stealth/src/http3_masq.rs
@@ -11,6 +11,10 @@ impl Masquerade {
 
     pub fn enable(&mut self, enable: bool) { self.enabled = enable; }
 
+    pub fn set_profile(&mut self, profile: BrowserProfile) {
+        self.profile = profile;
+    }
+
     pub fn headers(&self) -> HashMap<String, String> {
         if self.enabled {
             default_headers(self.profile)

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -60,10 +60,17 @@ impl QuicFuscateStealth {
     }
 
     pub fn enable_spinbit(&mut self, e: bool) { self.spin.enable(e); }
+    pub fn set_spinbit_probability(&mut self, p: f64) { self.spin.set_probability(p); }
+    pub fn enable_utls(&mut self, e: bool) { self.tls.enable(e); }
+    pub fn set_browser_profile(&mut self, profile: BrowserProfile) {
+        self.http3_masq.set_profile(profile);
+        self.tls.set_profile(profile);
+    }
     pub fn enable_domain_fronting(&mut self, e: bool) { self.domain_fronting.enable(e); }
     pub fn enable_http3_masq(&mut self, e: bool) { self.http3_masq.enable(e); }
     pub fn enable_doh(&mut self, e: bool) { self.doh.enable(e); }
     pub fn enable_zero_rtt(&mut self, e: bool) { self.zero_rtt.set_enabled(e); }
+    pub fn set_zero_rtt_max_early_data(&mut self, max: usize) { self.zero_rtt.set_max_early_data(max); }
 
     pub async fn resolve_domain(&mut self, domain: &str) -> std::net::IpAddr {
         self.doh.resolve(domain).await

--- a/rust/stealth/src/zero_rtt.rs
+++ b/rust/stealth/src/zero_rtt.rs
@@ -25,6 +25,7 @@ impl ZeroRttEngine {
     }
 
     pub fn set_enabled(&mut self, e: bool) { self.cfg.enabled = e; }
+    pub fn set_max_early_data(&mut self, max: usize) { self.cfg.max_early_data = max; }
 
     pub async fn send_early_data(&mut self, data: &[u8]) -> Result<(), ()> {
         self.attempts += 1;

--- a/rust/tests/tests/browser_fingerprinting.rs
+++ b/rust/tests/tests/browser_fingerprinting.rs
@@ -15,3 +15,10 @@ fn default_profiles_provide_user_agent() {
     let headers = default_headers(BrowserProfile::Firefox);
     assert!(headers.get("user-agent").is_some());
 }
+
+#[test]
+fn tls_fingerprint_changes_per_profile() {
+    let chrome = BrowserFingerprint::for_profile(BrowserProfile::Chrome);
+    let firefox = BrowserFingerprint::for_profile(BrowserProfile::Firefox);
+    assert_ne!(chrome.tls.cipher_suites, firefox.tls.cipher_suites);
+}

--- a/rust/tests/tests/stealth_full.rs
+++ b/rust/tests/tests/stealth_full.rs
@@ -18,3 +18,19 @@ fn domain_fronting_and_doh() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn stealth_toggles_and_zero_rtt() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut s = QuicFuscateStealth::new();
+        s.enable_zero_rtt(true);
+        s.set_zero_rtt_max_early_data(32);
+        s.set_spinbit_probability(1.0);
+        s.enable_spinbit(true);
+        assert!(s.zero_rtt.send_early_data(b"hello").await.is_ok());
+        assert!(!s.randomize_spinbit(true));
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}
+


### PR DESCRIPTION
## Summary
- expand TLS fingerprints per browser profile
- allow updating FakeTls profile and enable/disable uTLS
- expose config options in QuicFuscateStealth
- wire new options through CLI
- add integration tests for zero-RTT and spinbit

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6866eadcfc74833397b17620a837b546