### PR TITLE
Add simple RLNC FEC scheme

### DIFF
--- a/rust/fec/Cargo.toml
+++ b/rust/fec/Cargo.toml
@@ -13,6 +13,7 @@ rlnc = "0.3"
 leopard-codec = "0.1"
 reed-solomon-erasure = "6"
 serde = { version = "1", features = ["derive"] }
+rand = "0.8"
 
 [dev-dependencies]
 criterion = "0.5"


### PR DESCRIPTION
## Summary
- implement a basic random-linear-network-coding scheme in the FEC crate
- expose a `inverse` helper for GF(256) arithmetic
- allow RLNC recovery from repair packets in tests
- add `rand` dependency for coefficient generation

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68669b434b708333a38e6f80d74f75cb