### PR TITLE
Implement connect logic with quiche

### DIFF
--- a/rust/core/tests/quic_connection.rs
+++ b/rust/core/tests/quic_connection.rs
@@ -1,8 +1,23 @@
-use core::{QuicConfig, QuicConnection};
+use core::{QuicConfig, QuicConnection, CoreError};
 
 #[test]
 fn constructible() {
     let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
     let conn = QuicConnection::new(cfg);
     assert!(conn.is_ok());
+}
+
+#[test]
+fn connect_success() {
+    let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+    let mut conn = QuicConnection::new(cfg).unwrap();
+    assert!(conn.connect("127.0.0.1:443").is_ok());
+}
+
+#[test]
+fn connect_error() {
+    let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+    let mut conn = QuicConnection::new(cfg).unwrap();
+    let err = conn.connect("invalid").unwrap_err();
+    assert!(matches!(err, CoreError::Quic(_)));
 }


### PR DESCRIPTION
## Summary
- implement a `QuicConnection` state machine
- keep optional `quiche` dependency behind a feature
- implement address parsing and store a `quiche::Connection`
- extend `quic_connection` unit tests to cover successful and error cases

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6866f9f9a07c8333a2731232f60d5719