### PR TITLE
Replace FEC module singleton

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -352,7 +352,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "leopard-codec",
- "once_cell",
+ "rand 0.8.5",
  "reed-solomon-erasure",
  "rlnc",
  "serde",

--- a/rust/fec/Cargo.toml
+++ b/rust/fec/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 path = "src/lib.rs"
 
 [dependencies]
-once_cell = "1"
 thiserror = "1"
 rlnc = "0.3"
 leopard-codec = "0.1"

--- a/rust/tests/tests/fec_module.rs
+++ b/rust/tests/tests/fec_module.rs
@@ -5,20 +5,21 @@ use fec::{
 
 #[test]
 fn encode_decode() {
-    assert_eq!(0, fec_module_init());
+    let handle = fec_module_init();
+    assert!(!handle.is_null());
     let msg = b"hello";
     let mut enc_len = 0usize;
-    let enc_ptr = fec_module_encode(msg.as_ptr(), msg.len(), &mut enc_len as *mut usize);
+    let enc_ptr = fec_module_encode(handle, msg.as_ptr(), msg.len(), &mut enc_len as *mut usize);
     assert!(!enc_ptr.is_null());
     let enc_slice = unsafe { std::slice::from_raw_parts(enc_ptr, enc_len) };
     let enc = enc_slice.to_vec();
-    fec_module_free(enc_ptr, enc_len);
+    fec_module_free(handle, enc_ptr, enc_len);
     let mut dec_len = 0usize;
-    let dec_ptr = fec_module_decode(enc.as_ptr(), enc.len(), &mut dec_len as *mut usize);
+    let dec_ptr = fec_module_decode(handle, enc.as_ptr(), enc.len(), &mut dec_len as *mut usize);
     let dec_slice = unsafe { std::slice::from_raw_parts(dec_ptr, dec_len) };
     let dec = dec_slice.to_vec();
-    fec_module_free(dec_ptr, dec_len);
-    fec_module_cleanup();
+    fec_module_free(handle, dec_ptr, dec_len);
+    fec_module_cleanup(handle);
     assert_eq!(dec, msg);
 }
 

--- a/rust/tests/tests/fec_module_free.rs
+++ b/rust/tests/tests/fec_module_free.rs
@@ -2,17 +2,18 @@ use fec::{fec_module_encode, fec_module_decode, fec_module_init, fec_module_clea
 
 #[test]
 fn encode_decode_loop_with_free() {
-    assert_eq!(0, fec_module_init());
+    let handle = fec_module_init();
+    assert!(!handle.is_null());
     for _ in 0..100 {
         let msg = b"hello";
         let mut enc_len = 0usize;
-        let enc_ptr = fec_module_encode(msg.as_ptr(), msg.len(), &mut enc_len as *mut usize);
+        let enc_ptr = fec_module_encode(handle, msg.as_ptr(), msg.len(), &mut enc_len as *mut usize);
         assert!(!enc_ptr.is_null());
         let mut dec_len = 0usize;
-        let dec_ptr = fec_module_decode(enc_ptr, enc_len, &mut dec_len as *mut usize);
+        let dec_ptr = fec_module_decode(handle, enc_ptr, enc_len, &mut dec_len as *mut usize);
         assert!(!dec_ptr.is_null());
-        fec_module_free(enc_ptr, enc_len);
-        fec_module_free(dec_ptr, dec_len);
+        fec_module_free(handle, enc_ptr, enc_len);
+        fec_module_free(handle, dec_ptr, dec_len);
     }
-    fec_module_cleanup();
+    fec_module_cleanup(handle);
 }


### PR DESCRIPTION
## Summary
- remove `once_cell` usage and make `FECModule` instantiable
- change FFI to operate on module handles
- update tests to use a handle

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6866f9fc246c8333b43095058a5c9b37