### PR TITLE
Add CLI toggles for BBR and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ Run `quicfuscate_demo --help` to see all available options. Important flags incl
   -v, --verbose              Verbose logging
       --debug-tls            Show TLS debug information
       --list-fingerprints    List available browser fingerprints
+      --doh-ttl <secs>       DNS cache TTL (default: 300)
+      --migration            Enable QUIC connection migration
+      --bbr                 Enable BBRv2 congestion control
 ```
 
 ## 🔄 Continuous Integration

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@ version features connection migration, BBRv2 congestion control and XDP
 zero‑copy networking as outlined in the *Core Module* section of the original
 documentation【F:docs/DOCUMENTATION.md†L134-L139】. The Rust crate aims to
 replicate these features and expose a safe API for the rest of the workspace.
+Recent updates added stubbed support for connection migration and a
+placeholder BBRv2 controller so that higher layers can be exercised in tests.
+The CLI can now toggle these features via `--migration` and `--bbr`.
 
 ### Crypto Crate
 `crypto` contains hardware accelerated cipher implementations with automatic
@@ -28,18 +31,20 @@ code reuses the same concepts of AEGIS‑128X/L and MORUS‑1280‑128 with a
 `CipherSuiteSelector` to pick the optimal cipher based on CPU features.
 
 ### FEC Crate
-The Forward Error Correction crate currently offers a basic encoder and decoder
-and is intended to replace the old C++ implementation. Adaptive redundancy with
-memory-pooled buffers and SIMD optimised Galois field arithmetic are still in
-development as described in the original
-documentation【F:docs/DOCUMENTATION.md†L173-L202】. The module is experimental
-and not yet production ready.
+The Forward Error Correction crate offers a memory pooled encoder and decoder.
+An internal `MetricsSampler` now tracks loss history and optional adaptive
+callbacks can adjust the redundancy ratio dynamically. A simple stealth mode
+applies random padding to repair packets. SIMD optimised Galois field
+arithmetic remains under development as described in the original
+documentation【F:docs/DOCUMENTATION.md†L173-L202】. The module is still
+experimental.
 
 ### Stealth Crate
 Traffic obfuscation is handled by the `stealth` crate.  Basic XOR obfuscation,
-DoH tunnelling and domain fronting are already functional.  uTLS
-fingerprinting and HTTP/3 masquerading are in active development as outlined in
-the *Stealth Module* section of the C++ documentation【F:docs/DOCUMENTATION.md†L1888-L1905】.
+DoH tunnelling and domain fronting are already functional. The DoH client now
+supports cached lookups with a configurable TTL (set via `--doh-ttl`). uTLS fingerprinting and
+HTTP/3 masquerading remain in active development as outlined in the *Stealth
+Module* section of the C++ documentation【F:docs/DOCUMENTATION.md†L1888-L1905】.
 Like the FEC crate, this module is considered experimental and not production ready.
 
 ## Building & Testing the Rust Workspace

--- a/rust/cli/src/main.rs
+++ b/rust/cli/src/main.rs
@@ -74,8 +74,11 @@ fn main() {
     stealth.enable_domain_fronting(opts.domain_fronting);
     stealth.enable_http3_masq(opts.http3_masq);
     stealth.enable_doh(opts.doh);
+    stealth.set_doh_cache_ttl(opts.doh_ttl);
     stealth.enable_spinbit(opts.spin_random);
     stealth.enable_zero_rtt(opts.zero_rtt);
+    stealth.enable_migration(opts.migration);
+    stealth.enable_bbr(opts.bbr);
     if stealth.initialize() {
         info!("Stealth subsystem initialized.");
     } else {

--- a/rust/cli/src/options.rs
+++ b/rust/cli/src/options.rs
@@ -110,6 +110,18 @@ pub struct CommandLineOptions {
     #[arg(long, default_value_t = false)]
     pub doh: bool,
 
+    /// TTL for cached DoH responses in seconds
+    #[arg(long, default_value_t = 300)]
+    pub doh_ttl: u64,
+
+    /// Enable QUIC connection migration
+    #[arg(long, default_value_t = false)]
+    pub migration: bool,
+
+    /// Enable BBRv2 congestion control
+    #[arg(long, default_value_t = false)]
+    pub bbr: bool,
+
     /// Enable spinbit randomization
     #[arg(long, default_value_t = false)]
     pub spin_random: bool,

--- a/rust/cli/tests/cli_tests.rs
+++ b/rust/cli/tests/cli_tests.rs
@@ -8,6 +8,9 @@ fn default_values() -> Result<(), clap::Error> {
     assert_eq!(opts.port, 443);
     assert_eq!(opts.fingerprint, Fingerprint::Chrome);
     assert!(!opts.no_utls);
+    assert_eq!(opts.doh_ttl, 300);
+    assert!(!opts.migration);
+    assert!(!opts.bbr);
     Ok(())
 }
 
@@ -27,6 +30,10 @@ fn parse_custom_values() -> Result<(), clap::Error> {
         "cafile",
         "--verbose",
         "--debug-tls",
+        "--doh-ttl",
+        "600",
+        "--migration",
+        "--bbr",
     ])?;
     assert_eq!(opts.server, "host");
     assert_eq!(opts.port, 123);
@@ -36,6 +43,9 @@ fn parse_custom_values() -> Result<(), clap::Error> {
     assert_eq!(opts.ca_file.as_deref(), Some("cafile"));
     assert!(opts.verbose);
     assert!(opts.debug_tls);
+    assert_eq!(opts.doh_ttl, 600);
+    assert!(opts.migration);
+    assert!(opts.bbr);
     Ok(())
 }
 

--- a/rust/core/tests/quic_connection.rs
+++ b/rust/core/tests/quic_connection.rs
@@ -21,3 +21,30 @@ fn connect_error() {
     let err = conn.connect("invalid").unwrap_err();
     assert!(matches!(err, CoreError::Quic(_)));
 }
+
+#[test]
+fn migration_requires_enable() {
+    let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+    let mut conn = QuicConnection::new(cfg).unwrap();
+    assert!(conn.connect("127.0.0.1:443").is_ok());
+    let err = conn.migrate("127.0.0.2:443").unwrap_err();
+    assert!(matches!(err, CoreError::Quic(_)));
+}
+
+#[test]
+fn migration_works_when_enabled() {
+    let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+    let mut conn = QuicConnection::new(cfg).unwrap();
+    conn.enable_migration(true);
+    assert!(conn.connect("127.0.0.1:443").is_ok());
+    assert!(conn.migrate("127.0.0.2:443").is_ok());
+    assert_eq!(conn.current_path(), Some("127.0.0.2:443"));
+}
+
+#[test]
+fn enabling_bbr_creates_controller() {
+    let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+    let mut conn = QuicConnection::new(cfg).unwrap();
+    conn.enable_bbr_congestion_control(true);
+    assert!(conn.is_bbr_enabled());
+}

--- a/rust/crypto/tests/aegis128l_test.rs
+++ b/rust/crypto/tests/aegis128l_test.rs
@@ -36,3 +36,17 @@ fn encrypt_decrypt_vectors() -> Result<(), crypto::CryptoError> {
     assert_eq!(pt2, MSG);
     Ok(())
 }
+
+#[test]
+fn reject_tampered_tag() {
+    let cipher = Aegis128L::new();
+    let mut ct = Vec::new();
+    let mut tag = [0u8; 16];
+    cipher
+        .encrypt(MSG, &KEY, &NONCE, b"", &mut ct, &mut tag)
+        .unwrap();
+    tag[0] ^= 0xff;
+    let mut pt = Vec::new();
+    let res = cipher.decrypt(&ct, &KEY, &NONCE, b"", &tag, &mut pt);
+    assert!(res.is_err());
+}

--- a/rust/crypto/tests/morus_test.rs
+++ b/rust/crypto/tests/morus_test.rs
@@ -27,3 +27,17 @@ fn encrypt_decrypt_vectors() -> Result<(), crypto::CryptoError> {
     assert_eq!(pt, MSG);
     Ok(())
 }
+
+#[test]
+fn reject_tampered_tag() {
+    let cipher = Morus::new();
+    let mut ct = Vec::new();
+    let mut tag = [0u8; 16];
+    cipher
+        .encrypt(MSG, &KEY, &NONCE, b"", &mut ct, &mut tag)
+        .unwrap();
+    tag[0] ^= 1;
+    let mut pt = Vec::new();
+    let res = cipher.decrypt(&ct, &KEY, &NONCE, b"", &tag, &mut pt);
+    assert!(res.is_err());
+}

--- a/rust/stealth/src/doh.rs
+++ b/rust/stealth/src/doh.rs
@@ -4,17 +4,18 @@ use std::net::{IpAddr, Ipv4Addr};
 #[derive(Clone)]
 pub struct DohConfig {
     pub enable_caching: bool,
+    pub cache_ttl_secs: u64,
 }
 
 impl Default for DohConfig {
     fn default() -> Self {
-        Self { enable_caching: true }
+        Self { enable_caching: true, cache_ttl_secs: 300 }
     }
 }
 
 pub struct DohClient {
     config: DohConfig,
-    cache: HashMap<String, IpAddr>,
+    cache: HashMap<String, (IpAddr, std::time::Instant)>,
     enabled: bool,
 }
 
@@ -25,14 +26,22 @@ impl DohClient {
 
     pub fn enable(&mut self, enable: bool) { self.enabled = enable; }
 
+    pub fn cache_size(&self) -> usize { self.cache.len() }
+
+    pub fn set_cache_ttl(&mut self, ttl: u64) { self.config.cache_ttl_secs = ttl; }
+
+    pub fn cache_ttl(&self) -> u64 { self.config.cache_ttl_secs }
+
     /// Simplified asynchronous resolver that returns a fixed IP address.
     pub async fn resolve(&mut self, domain: &str) -> IpAddr {
         if !self.enabled {
             return IpAddr::V4(Ipv4Addr::new(127,0,0,1));
         }
         if self.config.enable_caching {
-            if let Some(ip) = self.cache.get(domain) {
-                return *ip;
+            if let Some((ip, t)) = self.cache.get(domain) {
+                if t.elapsed().as_secs() < self.config.cache_ttl_secs {
+                    return *ip;
+                }
             }
         }
         let ip = if domain == "example.com" {
@@ -41,8 +50,12 @@ impl DohClient {
             IpAddr::V4(Ipv4Addr::new(1, 1, 1, 1))
         };
         if self.config.enable_caching {
-            self.cache.insert(domain.to_string(), ip);
+            self.cache.insert(domain.to_string(), (ip, std::time::Instant::now()));
         }
         ip
+    }
+
+    pub fn clear_cache(&mut self) {
+        self.cache.clear();
     }
 }

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -32,6 +32,8 @@ pub struct QuicFuscateStealth {
     pub http3_masq: Masquerade,
     pub doh: DohClient,
     pub tls: FakeTls,
+    migration_enabled: bool,
+    bbr_enabled: bool,
 }
 
 impl QuicFuscateStealth {
@@ -46,6 +48,8 @@ impl QuicFuscateStealth {
             http3_masq: Masquerade::new(BrowserProfile::Chrome),
             doh: DohClient::new(DohConfig::default()),
             tls: FakeTls::new(BrowserProfile::Chrome),
+            migration_enabled: false,
+            bbr_enabled: false,
         }
     }
 
@@ -69,6 +73,11 @@ impl QuicFuscateStealth {
     pub fn enable_domain_fronting(&mut self, e: bool) { self.domain_fronting.enable(e); }
     pub fn enable_http3_masq(&mut self, e: bool) { self.http3_masq.enable(e); }
     pub fn enable_doh(&mut self, e: bool) { self.doh.enable(e); }
+    pub fn set_doh_cache_ttl(&mut self, ttl: u64) { self.doh.set_cache_ttl(ttl); }
+    pub fn enable_migration(&mut self, e: bool) { self.migration_enabled = e; }
+    pub fn enable_bbr(&mut self, e: bool) { self.bbr_enabled = e; }
+    pub fn is_migration_enabled(&self) -> bool { self.migration_enabled }
+    pub fn is_bbr_enabled(&self) -> bool { self.bbr_enabled }
     pub fn enable_zero_rtt(&mut self, e: bool) { self.zero_rtt.set_enabled(e); }
     pub fn set_zero_rtt_max_early_data(&mut self, max: usize) { self.zero_rtt.set_max_early_data(max); }
 

--- a/rust/tests/tests/stealth_full.rs
+++ b/rust/tests/tests/stealth_full.rs
@@ -34,3 +34,36 @@ fn stealth_toggles_and_zero_rtt() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[test]
+fn doh_cache_expires() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut s = QuicFuscateStealth::new();
+        s.enable_doh(true);
+        let ip1 = s.resolve_domain("example.com").await;
+        assert_eq!(ip1.to_string(), "93.184.216.34");
+        // set ttl very short and resolve again after sleeping
+        s.doh.set_cache_ttl(1);
+        let _ = s.resolve_domain("example.com").await;
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        let _ = s.resolve_domain("example.com").await;
+        assert_eq!(s.doh.cache_size(), 1);
+        s.doh.clear_cache();
+        assert_eq!(s.doh.cache_size(), 0);
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}
+
+#[test]
+fn migration_and_bbr_flags() {
+    let mut s = QuicFuscateStealth::new();
+    assert!(!s.is_migration_enabled());
+    assert!(!s.is_bbr_enabled());
+    s.enable_migration(true);
+    s.enable_bbr(true);
+    assert!(s.is_migration_enabled());
+    assert!(s.is_bbr_enabled());
+    s.set_doh_cache_ttl(120);
+    assert_eq!(s.doh.cache_ttl(), 120);
+}


### PR DESCRIPTION
## Summary
- expose BBR, migration and DoH TTL options in the CLI
- allow Stealth module to control DoH cache TTL, BBR and migration
- document new command line flags
- test the new flags and Stealth behaviour

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6866fddfc5cc83338541552db98b9c07