### PR TITLE
Implement congestion control and FEC safety wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
               choco install cppcheck -y
             fi
           fi
-          cppcheck --error-exitcode=1 -q cli || true
+          cppcheck --error-exitcode=1 -q cli
 
       - name: Build
         shell: bash

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ mirror URL):
 ./scripts/fetch_quiche.sh [mirror-url]
 ```
 
+If a local copy of quiche already exists, set the `QUICHE_PATH` environment
+variable to skip fetching and build from that path instead.
+
 ### Building quiche
 
 Compile the patched **quiche** library using Cargo:

--- a/rust/core/tests/bbr_controller.rs
+++ b/rust/core/tests/bbr_controller.rs
@@ -1,0 +1,17 @@
+use core::BbrCongestionController;
+
+#[test]
+fn cwnd_increases_on_ack() {
+    let mut bbr = BbrCongestionController::new();
+    let before = bbr.cwnd();
+    bbr.on_packet_acknowledged(1500);
+    assert!(bbr.cwnd() > before);
+}
+
+#[test]
+fn cwnd_decreases_on_loss() {
+    let mut bbr = BbrCongestionController::new();
+    bbr.on_packet_acknowledged(1500);
+    bbr.on_packet_lost();
+    assert!(bbr.cwnd() <= 10_000);
+}

--- a/rust/core/tests/path_mtu_manager.rs
+++ b/rust/core/tests/path_mtu_manager.rs
@@ -1,15 +1,15 @@
-use core::{PathMtuManager, DEFAULT_MAX_MTU, DEFAULT_MIN_MTU};
+use core::{PathMtuManager, DEFAULT_MAX_MTU, DEFAULT_MIN_MTU, RFC_8899_MIN_MTU};
 
 #[test]
 fn constants_range() {
-    assert!(DEFAULT_MIN_MTU >= 1200);
+    assert!(DEFAULT_MIN_MTU >= RFC_8899_MIN_MTU);
     assert!(DEFAULT_MIN_MTU <= DEFAULT_MAX_MTU);
 }
 
 #[test]
 fn probe_methods_exist() {
     let mut mgr = PathMtuManager::new();
-    let id = mgr.send_probe(1200, false);
+    let id = mgr.send_probe(DEFAULT_MIN_MTU, false);
     mgr.handle_probe_response(id, true, false);
 }
 
@@ -18,7 +18,8 @@ fn enable_bidirectional() {
     let mut mgr = PathMtuManager::new();
     mgr.enable_bidirectional_discovery(true);
     assert!(mgr.is_bidirectional_discovery_enabled());
-    mgr.set_mtu_size(1300, true);
-    assert_eq!(mgr.get_outgoing_mtu(), 1300);
-    assert_eq!(mgr.get_incoming_mtu(), 1300);
+    let size = DEFAULT_MIN_MTU + 100;
+    mgr.set_mtu_size(size, true);
+    assert_eq!(mgr.get_outgoing_mtu(), size);
+    assert_eq!(mgr.get_incoming_mtu(), size);
 }

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -1,3 +1,5 @@
+//! High level traffic obfuscation utilities.
+
 pub mod browser;
 pub mod datagram;
 pub mod doh;
@@ -12,15 +14,15 @@ pub mod zero_rtt;
 
 pub use browser::{BrowserFingerprint, BrowserProfile, BrowserType, OperatingSystem};
 use datagram::DatagramEngine;
+use doh::{DohClient, DohConfig};
+use domain_fronting::{SniConfig, SniHiding};
+use fake_tls::FakeTls;
+use http3_masq::Masquerade;
 use qpack::QpackEngine;
 use spinbit::SpinBitRandomizer;
 use stream::StreamEngine;
 pub use xor::{XORConfig, XORObfuscator, XORPattern};
 use zero_rtt::ZeroRttEngine;
-use domain_fronting::{SniConfig, SniHiding};
-use doh::{DohClient, DohConfig};
-use http3_masq::Masquerade;
-use fake_tls::FakeTls;
 
 pub struct QuicFuscateStealth {
     pub qpack: QpackEngine,
@@ -59,24 +61,42 @@ impl QuicFuscateStealth {
         self.spin.randomize(bit)
     }
 
-    pub fn enable_spinbit(&mut self, e: bool) { self.spin.enable(e); }
-    pub fn set_spinbit_probability(&mut self, p: f64) { self.spin.set_probability(p); }
-    pub fn enable_utls(&mut self, e: bool) { self.tls.enable(e); }
+    pub fn enable_spinbit(&mut self, e: bool) {
+        self.spin.enable(e);
+    }
+    pub fn set_spinbit_probability(&mut self, p: f64) {
+        self.spin.set_probability(p);
+    }
+    pub fn enable_utls(&mut self, e: bool) {
+        self.tls.enable(e);
+    }
     pub fn set_browser_profile(&mut self, profile: BrowserProfile) {
         self.http3_masq.set_profile(profile);
         self.tls.set_profile(profile);
     }
-    pub fn enable_domain_fronting(&mut self, e: bool) { self.domain_fronting.enable(e); }
-    pub fn enable_http3_masq(&mut self, e: bool) { self.http3_masq.enable(e); }
-    pub fn enable_doh(&mut self, e: bool) { self.doh.enable(e); }
-    pub fn enable_zero_rtt(&mut self, e: bool) { self.zero_rtt.set_enabled(e); }
-    pub fn set_zero_rtt_max_early_data(&mut self, max: usize) { self.zero_rtt.set_max_early_data(max); }
+    pub fn enable_domain_fronting(&mut self, e: bool) {
+        self.domain_fronting.enable(e);
+    }
+    pub fn enable_http3_masq(&mut self, e: bool) {
+        self.http3_masq.enable(e);
+    }
+    pub fn enable_doh(&mut self, e: bool) {
+        self.doh.enable(e);
+    }
+    pub fn enable_zero_rtt(&mut self, e: bool) {
+        self.zero_rtt.set_enabled(e);
+    }
+    pub fn set_zero_rtt_max_early_data(&mut self, max: usize) {
+        self.zero_rtt.set_max_early_data(max);
+    }
 
     pub async fn resolve_domain(&mut self, domain: &str) -> std::net::IpAddr {
         self.doh.resolve(domain).await
     }
 
-    pub fn generate_client_hello(&self) -> Vec<u8> { self.tls.generate_client_hello() }
+    pub fn generate_client_hello(&self) -> Vec<u8> {
+        self.tls.generate_client_hello()
+    }
 
     pub fn apply_domain_fronting(&self, headers: &str) -> String {
         self.domain_fronting.apply_domain_fronting(headers)

--- a/rust/tests/tests/path_mtu_manager.rs
+++ b/rust/tests/tests/path_mtu_manager.rs
@@ -1,11 +1,11 @@
 use core::{
-    MtuStatus, PathMtuManager, DEFAULT_MAX_MTU, DEFAULT_MIN_MTU,
+    MtuStatus, PathMtuManager, DEFAULT_MAX_MTU, DEFAULT_MIN_MTU, RFC_8899_MIN_MTU,
     DEFAULT_PATH_BLACKHOLE_THRESHOLD, DEFAULT_INITIAL_MTU, DEFAULT_MTU_STEP_SIZE,
 };
 
 #[test]
 fn constants() {
-    assert!(DEFAULT_MIN_MTU >= 1200);
+    assert!(DEFAULT_MIN_MTU >= RFC_8899_MIN_MTU);
     assert!(DEFAULT_MIN_MTU <= DEFAULT_MAX_MTU);
 }
 

--- a/rust/tests/tests/stealth_extra.rs
+++ b/rust/tests/tests/stealth_extra.rs
@@ -1,0 +1,40 @@
+use stealth::{
+    doh::{DohClient, DohConfig},
+    domain_fronting::{SniConfig, SniHiding},
+    fake_tls::FakeTls,
+    BrowserProfile,
+};
+use tokio::runtime::Runtime;
+
+#[test]
+fn fake_tls_client_hello_non_empty() {
+    let tls = FakeTls::new(BrowserProfile::Chrome);
+    let hello = tls.generate_client_hello();
+    assert!(!hello.is_empty());
+    assert_eq!(hello[0], 0x16);
+}
+
+#[test]
+fn domain_fronting_replaces_header() {
+    let mut df = SniHiding::new(SniConfig {
+        front_domain: "front.example.com".into(),
+        real_domain: "real.example.com".into(),
+    });
+    df.enable(true);
+    let out = df.apply_domain_fronting("Host: real.example.com");
+    assert!(out.contains("front.example.com"));
+}
+
+#[test]
+fn doh_resolver_caches_result() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let mut client = DohClient::new(DohConfig::default());
+        client.enable(true);
+        let first = client.resolve("example.com").await;
+        let second = client.resolve("example.com").await;
+        assert_eq!(first, second);
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}

--- a/scripts/fetch_quiche.sh
+++ b/scripts/fetch_quiche.sh
@@ -4,6 +4,14 @@ set -e
 MIRROR_URL=${1:-https://github.com/cloudflare/quiche.git}
 SUBMODULE_PATH="libs/quiche-patched"
 
+if [ -n "$QUICHE_PATH" ] && [ -d "$QUICHE_PATH" ]; then
+    echo "Using local quiche from $QUICHE_PATH"
+    cd "$QUICHE_PATH"
+    cargo build --release
+    cargo clippy --all-targets -- -D warnings
+    exit 0
+fi
+
 if [ ! -d "$SUBMODULE_PATH" ]; then
     mkdir -p "$SUBMODULE_PATH"
 fi


### PR DESCRIPTION
## Summary
- add crate level docs across workspace
- implement a minimal BBR congestion controller
- expose safe `FecHandle` wrapper for FFI
- add integration tests for stealth features
- allow using local quiche via `QUICHE_PATH`
- tighten cppcheck step in CI
- document quiche path usage

## Testing
- `cargo test --workspace --manifest-path rust/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68670bce43ac8333b9af71b29171a054