### PR TITLE
Add Default impls and Display

### DIFF
--- a/rust/core/src/lib.rs
+++ b/rust/core/src/lib.rs
@@ -90,6 +90,7 @@ pub enum ConnectionState {
 }
 
 pub struct QuicConnection {
+    #[allow(dead_code)]
     config: QuicConfig,
     mtu_discovery: bool,
     migration: bool,
@@ -270,6 +271,12 @@ pub struct PathMtuManager {
     incoming_failures: u8,
     blackhole_threshold: u8,
     callback: Option<Box<dyn Fn(MtuChange) + Send + Sync>>,
+}
+
+impl Default for PathMtuManager {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PathMtuManager {
@@ -547,6 +554,12 @@ pub struct QuicStreamOptimizer {
     base_chunk: u32,
 }
 
+impl Default for QuicStreamOptimizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl QuicStreamOptimizer {
     pub fn new() -> Self {
         Self {
@@ -563,7 +576,7 @@ impl QuicStreamOptimizer {
         let entry = self
             .streams
             .entry(stream_id)
-            .or_insert_with(StreamInfo::default);
+            .or_default();
         entry.priority = priority;
         true
     }
@@ -572,7 +585,7 @@ impl QuicStreamOptimizer {
         let entry = self
             .streams
             .entry(stream_id)
-            .or_insert_with(StreamInfo::default);
+            .or_default();
         entry.window = size;
         true
     }

--- a/rust/core/src/quic_packet.rs
+++ b/rust/core/src/quic_packet.rs
@@ -53,6 +53,12 @@ pub struct QuicPacket {
     pub payload: Vec<u8>,
 }
 
+impl Default for QuicPacket {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl QuicPacket {
     pub fn new() -> Self {
         Self {
@@ -135,9 +141,12 @@ impl QuicPacket {
     pub fn size(&self) -> usize {
         17 + self.payload.len()
     }
+}
 
-    pub fn to_string(&self) -> String {
-        format!(
+impl std::fmt::Display for QuicPacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
             "QuicPacket[type={:?}, version=0x{:08x}, conn_id=0x{:016x}, pkt_num={}, payload_size={}]",
             self.header.packet_type,
             self.header.version,

--- a/rust/stealth/src/datagram.rs
+++ b/rust/stealth/src/datagram.rs
@@ -37,6 +37,12 @@ pub struct DatagramEngine {
     max_bundle: usize,
 }
 
+impl Default for DatagramEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DatagramEngine {
     pub fn new() -> Self {
         Self {

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -36,6 +36,12 @@ pub struct QuicFuscateStealth {
     pub tls: FakeTls,
 }
 
+impl Default for QuicFuscateStealth {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl QuicFuscateStealth {
     pub fn new() -> Self {
         Self {

--- a/rust/stealth/src/spinbit.rs
+++ b/rust/stealth/src/spinbit.rs
@@ -5,6 +5,12 @@ pub struct SpinBitRandomizer {
     enabled: bool,
 }
 
+impl Default for SpinBitRandomizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SpinBitRandomizer {
     pub fn new() -> Self {
         Self { probability: 0.5, enabled: true }

--- a/rust/stealth/src/stream.rs
+++ b/rust/stealth/src/stream.rs
@@ -12,6 +12,12 @@ pub struct StreamEngine {
     streams: HashMap<u64, Stream>,
 }
 
+impl Default for StreamEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum StreamError {
     #[error("no data available")]

--- a/rust/stealth/src/xor.rs
+++ b/rust/stealth/src/xor.rs
@@ -43,6 +43,12 @@ pub struct XORObfuscator {
     rng: SmallRng,
 }
 
+impl Default for XORObfuscator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl XORObfuscator {
     /// Create a new obfuscator with default configuration.
     pub fn new() -> Self {

--- a/rust/stealth/src/zero_rtt.rs
+++ b/rust/stealth/src/zero_rtt.rs
@@ -15,6 +15,12 @@ pub struct ZeroRttEngine {
     pub successes: usize,
 }
 
+impl Default for ZeroRttEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ZeroRttEngine {
     pub fn new() -> Self {
         Self { cfg: ZeroRttConfig::default(), attempts: 0, successes: 0 }


### PR DESCRIPTION
## Summary
- implement `Default` for several core and stealth types
- switch `QuicPacket` to use the `Display` trait instead of `to_string`
- silence dead code warning on `QuicConnection` config
- use `or_default()` for stream entries

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686785cd8c3c833394b4b01b34cddb40