### PR TITLE
Implement uTLS and HTTP/3 stealth features

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1536,6 +1536,7 @@ dependencies = [
  "quicfuscate-error",
  "rand 0.8.5",
  "reqwest",
+ "rustls",
  "serde_json",
  "thiserror",
  "tokio",

--- a/rust/stealth/Cargo.toml
+++ b/rust/stealth/Cargo.toml
@@ -14,6 +14,7 @@ thiserror = "1"
 quicfuscate-error = { path = "../error" }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["rustls-tls"] }
 serde_json = { version = "1", optional = true }
+rustls = "0.21"
 
 [features]
 doh-reqwest = ["reqwest", "serde_json"]

--- a/rust/stealth/src/http3_masq.rs
+++ b/rust/stealth/src/http3_masq.rs
@@ -36,4 +36,11 @@ impl Masquerade {
         h.insert(":authority".into(), "example.com".into());
         h
     }
+
+    /// Encode request headers using the provided QPACK engine.
+    pub fn encode_request(&self, path: &str, qpack: &mut crate::qpack::QpackEngine) -> Vec<u8> {
+        let headers = self.request_headers(path);
+        let pairs: Vec<(String, String)> = headers.into_iter().collect();
+        qpack.encode(&pairs)
+    }
 }

--- a/rust/stealth/src/lib.rs
+++ b/rust/stealth/src/lib.rs
@@ -107,4 +107,12 @@ impl QuicFuscateStealth {
     pub fn apply_domain_fronting(&self, headers: &str) -> String {
         self.domain_fronting.apply_domain_fronting(headers)
     }
+
+    pub fn apply_sni_fronting(&self, hello: &[u8]) -> Vec<u8> {
+        self.domain_fronting.apply_tls_fronting(hello)
+    }
+
+    pub fn generate_h3_request(&mut self, path: &str) -> Vec<u8> {
+        self.http3_masq.encode_request(path, &mut self.qpack)
+    }
 }

--- a/rust/tests/tests/stealth_quic.rs
+++ b/rust/tests/tests/stealth_quic.rs
@@ -1,0 +1,37 @@
+use stealth::{QuicFuscateStealth, BrowserProfile};
+use core::{QuicConfig, QuicConnection};
+use tokio::runtime::Runtime;
+
+#[test]
+fn stealth_quic_negotiation() -> Result<(), Box<dyn std::error::Error>> {
+    let rt = Runtime::new()?;
+    rt.block_on(async {
+        let cfg = QuicConfig { server_name: "localhost".into(), port: 443 };
+        let mut client = QuicConnection::new(cfg.clone())?;
+        let mut server = QuicConnection::new(cfg)?;
+        client.connect("127.0.0.1:443")?;
+        server.connect("127.0.0.1:443")?;
+
+        let mut stealth = QuicFuscateStealth::new();
+        stealth.domain_fronting = stealth::domain_fronting::SniHiding::new(
+            stealth::domain_fronting::SniConfig {
+                front_domain: "front.example.com".into(),
+                real_domain: "example.com".into(),
+            },
+        );
+        stealth.set_browser_profile(BrowserProfile::Chrome);
+        stealth.enable_utls(true);
+        stealth.enable_domain_fronting(true);
+        stealth.enable_http3_masq(true);
+
+        let hello = stealth.generate_client_hello();
+        assert!(!hello.is_empty());
+        let fronted = stealth.apply_sni_fronting(&hello);
+        assert_ne!(hello, fronted);
+
+        let req = stealth.generate_h3_request("/");
+        assert!(req.windows(5).any(|w| w == b":path"));
+        Ok::<(), Box<dyn std::error::Error>>(())
+    })?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add rustls dependency to stealth crate
- implement TLS SNI fronting and HTTP/3 request encoding
- build real ClientHello using rustls
- expose helper methods in `QuicFuscateStealth`
- add integration test for stealth negotiation over QUIC

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_6867c2d6135083338cb72b4fcc27ebd4