### PR TITLE
Add runtime fingerprint profile switching

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,11 @@
 # QuicFuscate Changelog
 
+## [2024-12-23] - Runtime Fingerprint Switching
+
+### ✨ Added
+- CLI flag `--profile` selects the browser fingerprint (`chrome`, `firefox`, `opera`, `brave`).
+- `StealthManager::set_fingerprint_profile` allows runtime switching and updates QUIC parameters via `apply_utls_profile`.
+
 ## [2024-12-22] - Deprecated C++ Removal
 
 ### 🔥 Removed


### PR DESCRIPTION
## Summary
- allow selecting browser profile via `--profile`
- update `StealthManager` to switch `FingerprintProfile` dynamically
- reapply QUIC parameters when profiles change
- document the new feature in `Changelog`

## Testing
- `cargo test` *(fails: failed to load quiche submodule)*

------
https://chatgpt.com/codex/tasks/task_e_68680df665bc8333abf98eb359c47eb5