### PR TITLE
Implement stealth enhancements

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -163,6 +163,12 @@ impl CryptoManager {
         OsRng.fill_bytes(&mut key);
         key
     }
+
+    /// Generates a session specific key. This helper wraps [`get_obfuscation_key`]
+    /// to make the intent clear when a new connection is created.
+    pub fn generate_session_key(&self, length: usize) -> Vec<u8> {
+        self.get_obfuscation_key(length)
+    }
 }
 
 impl Default for CryptoManager {


### PR DESCRIPTION
## Summary
- use CryptoManager to generate session keys
- extend browser profiles and adjust fingerprints
- add TLS ClientHello spoofing placeholder
- integrate domain fronting with QuicFuscateConnection
- support QPACK-compressed HTTP/3 masquerading headers

## Testing
- `cargo check` *(fails: failed to read patched quiche)*

------
https://chatgpt.com/codex/tasks/task_e_6868125926448333a55902419c02e7c6