### PR TITLE
Extend core FEC integration

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -43,6 +43,7 @@ use crate::stealth::{StealthManager, StealthConfig};
 use std::collections::VecDeque;
 use std::net::{SocketAddr, Ipv4Addr};
 use std::sync::Arc;
+use std::time::Instant;
 
 /// Represents a single QuicFuscate connection and manages its state.
 pub struct QuicFuscateConnection {
@@ -61,6 +62,7 @@ pub struct QuicFuscateConnection {
     // State
     stats: ConnectionStats,
     packet_id_counter: u64,
+    handshake_start: Instant,
     // The outgoing buffer now holds fully formed FEC packets, ready for direct sending.
     // This eliminates the serialization overhead entirely.
     outgoing_fec_packets: VecDeque<FecPacket>,
@@ -74,6 +76,27 @@ pub struct ConnectionStats {
     pub loss_rate: f32,
     pub packets_sent: u64,
     pub packets_lost: u64,
+    pub bytes_sent: u64,
+    pub bytes_received: u64,
+    pub fec_repair_generated: u64,
+    pub fec_repair_received: u64,
+    pub handshake_time_ms: Option<u128>,
+}
+
+/// Unified error type for core connection operations.
+#[derive(Debug)]
+pub enum CoreError {
+    Quiche(quiche::Error),
+    Io(std::io::Error),
+    Other(String),
+}
+
+impl From<quiche::Error> for CoreError {
+    fn from(e: quiche::Error) -> Self { CoreError::Quiche(e) }
+}
+
+impl From<std::io::Error> for CoreError {
+    fn from(e: std::io::Error) -> Self { CoreError::Io(e) }
 }
 
 impl QuicFuscateConnection {
@@ -83,7 +106,7 @@ impl QuicFuscateConnection {
         remote_addr: SocketAddr,
         mut config: quiche::Config,
         stealth_config: StealthConfig,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, CoreError> {
         // --- Explicitly set BBRv2 Congestion Control as per PLAN.txt ---
         config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
         // --- Enable MTU Discovery ---
@@ -99,7 +122,7 @@ impl QuicFuscateConnection {
         let local_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
         
         let conn = quiche::connect(Some(server_name), &scid, local_addr, remote_addr, &mut config)
-            .map_err(|e| format!("Failed to create QUIC connection: {}", e))?;
+            .map_err(CoreError::from)?;
             
         let xdp_socket = optimization_manager.create_xdp_socket(local_addr, remote_addr);
         Ok(Self::new(conn, local_addr, remote_addr, stealth_manager, optimization_manager, xdp_socket))
@@ -112,7 +135,7 @@ impl QuicFuscateConnection {
         remote_addr: SocketAddr,
         mut config: quiche::Config,
         stealth_config: StealthConfig,
-    ) -> Result<Self, String> {
+    ) -> Result<Self, CoreError> {
         config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
         config.enable_mtu_probing();
 
@@ -121,7 +144,7 @@ impl QuicFuscateConnection {
         let stealth_manager = Arc::new(StealthManager::new(stealth_config, crypto_manager.clone(), optimization_manager.clone()));
         
         let conn = quiche::accept(scid, odcid, local_addr, remote_addr, &mut config)
-            .map_err(|e| format!("Failed to accept QUIC connection: {}", e))?;
+            .map_err(CoreError::from)?;
 
         let xdp_socket = optimization_manager.create_xdp_socket(local_addr, remote_addr);
 
@@ -159,24 +182,27 @@ impl QuicFuscateConnection {
             packet_id_counter: 0,
             outgoing_fec_packets: VecDeque::new(),
             xdp_socket,
+            handshake_start: Instant::now(),
         }
     }
 
     /// Processes an incoming raw buffer, parsing it into an FEC packet and handling recovery.
     /// This now avoids any serialization overhead.
-    pub fn recv(&mut self, data: &mut [u8]) -> Result<usize, String> {
+    pub fn recv(&mut self, data: &mut [u8]) -> Result<usize, CoreError> {
         let len = if let Some(ref xdp) = self.xdp_socket {
-            xdp.recv(data).map_err(|e| e.to_string())?
+            xdp.recv(data).map_err(CoreError::from)?
         } else {
             data.len()
         };
 
-        let fec_packet = FecPacket::from_raw(self.packet_id_counter, &data[..len], &self.optimization_manager)?;
+        let fec_packet = FecPacket::from_raw(self.packet_id_counter, &data[..len], &self.optimization_manager)
+            .map_err(CoreError::Other)?;
 
         let recovered_packets = self.fec.on_receive(fec_packet)
-            .map_err(|e| format!("FEC decoding failed: {}", e))?;
+            .map_err(|e| CoreError::Other(format!("FEC decoding failed: {}", e)))?;
 
         for mut packet in recovered_packets {
+            self.stats.fec_repair_received += (!packet.is_systematic) as u64;
             // Deobfuscate payload if enabled
             self.stealth_manager.process_incoming_packet(&mut packet.data);
             
@@ -186,6 +212,7 @@ impl QuicFuscateConnection {
                 // Log error, but continue processing other recovered packets
                 eprintln!("quiche::recv failed after FEC recovery: {}", e);
             }
+            self.stats.bytes_received += packet.len as u64;
         }
         
         Ok(len)
@@ -193,15 +220,17 @@ impl QuicFuscateConnection {
     
     /// Prepares QUIC packets for sending, wraps them in FEC, and buffers them.
     /// This has been completely refactored to eliminate serialization and copies.
-    pub fn send(&mut self, buf: &mut [u8]) -> Result<usize, quiche::Error> {
+    pub fn send(&mut self, buf: &mut [u8]) -> Result<usize, CoreError> {
         // If there are buffered FEC packets, send one directly.
         if let Some(packet) = self.outgoing_fec_packets.pop_front() {
             if let Some(ref xdp) = self.xdp_socket {
                 xdp.send(&[&packet.data[..packet.len]])
-                    .map_err(|_| quiche::Error::Done)?;
+                    .map_err(CoreError::from)?;
+                self.stats.bytes_sent += packet.len as u64;
                 return Ok(packet.len);
             } else {
                 let written = packet.to_raw(buf)?;
+                self.stats.bytes_sent += written as u64;
                 return Ok(written);
             }
         }
@@ -213,7 +242,7 @@ impl QuicFuscateConnection {
             Err(e) => {
                 // Return buffer to the pool on failure
                 self.optimization_manager.free_block(send_buffer);
-                return Err(e);
+                return Err(CoreError::from(e));
             }
         };
 
@@ -240,16 +269,24 @@ impl QuicFuscateConnection {
 
         // Pass to FEC encoder to get original + repair packets.
         // The encoder now directly populates the outgoing queue.
+        let before = self.outgoing_fec_packets.len();
         self.fec.on_send(fec_packet, &mut self.outgoing_fec_packets);
+        let after = self.outgoing_fec_packets.len();
+        if after > before {
+            // first packet is systematic
+            self.stats.fec_repair_generated += (after - before - 1) as u64;
+        }
 
         // Pop the first packet from the buffer to send it now.
         if let Some(packet) = self.outgoing_fec_packets.pop_front() {
             if let Some(ref xdp) = self.xdp_socket {
                 xdp.send(&[&packet.data[..packet.len]])
-                    .map_err(|_| quiche::Error::Done)?;
+                    .map_err(CoreError::from)?;
+                self.stats.bytes_sent += packet.len as u64;
                 Ok(packet.len)
             } else {
                 let written = packet.to_raw(buf)?;
+                self.stats.bytes_sent += written as u64;
                 Ok(written)
             }
         } else {
@@ -274,6 +311,10 @@ impl QuicFuscateConnection {
             self.stats.loss_rate = stats.lost as f32 / stats.sent as f32;
         }
         self.stats.rtt = stats.rtt.as_millis() as f32;
+
+        if self.stats.handshake_time_ms.is_none() && self.conn.is_established() {
+            self.stats.handshake_time_ms = Some(self.handshake_start.elapsed().as_millis());
+        }
         
         // Report stats to the adaptive FEC controller.
         self.fec.report_loss(stats.lost as usize, stats.sent as usize);

--- a/tests/core_integration.rs
+++ b/tests/core_integration.rs
@@ -1,0 +1,23 @@
+use quicfuscate::{core::QuicFuscateConnection, stealth::StealthConfig};
+use std::net::{SocketAddr, Ipv4Addr};
+
+#[test]
+fn config_enables_bbrv2_and_mtu() {
+    let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
+    config.enable_mtu_probing();
+    assert!(config.mtu_probing_enabled());
+}
+
+#[test]
+fn connection_migration_api() {
+    let mut config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    let stealth = StealthConfig::default();
+    let conn = QuicFuscateConnection::new_client(
+        "localhost",
+        SocketAddr::from((Ipv4Addr::LOCALHOST, 1234)),
+        config,
+        stealth,
+    );
+    assert!(conn.is_ok());
+}


### PR DESCRIPTION
## Summary
- enhance connection stats and handshake tracking
- unify core error handling
- integrate FEC metrics and byte counters
- add basic integration tests for config and migration

## Testing
- `cargo test` *(fails: failed to get `quiche` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6868126866588333a977367c9b53d99a