### PR TITLE
Add fetch script for patched quiche

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aligned_box = "0.2"
-quiche = { path = "libs/patched_quiche/quiche" }
+quiche = { path = "libs/patched_quiche/quiche/quiche" }
 rustls = "0.22.2"
 aegis = { version = "0.9.0", features = ["aegis-128x"] }
 morus = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -74,27 +74,27 @@ The codebase is now entirely written in Rust. Development focuses on expanding f
 ## 🔧 Build Instructions
 
 This repository uses a Git submodule to include a patched QUIC library.
-The `libs/quiche-patched` directory is intentionally left empty in the
+The `libs/patched_quiche` directory is intentionally left empty in the
 repository to avoid bloating the checkout size. Fetch the sources after
 cloning using one of the methods below.
 After cloning the project, initialize the submodule with:
 
 ```bash
-git submodule update --init --recursive libs/quiche-patched
+git submodule update --init --recursive libs/patched_quiche/quiche
 ```
 
 If the command fails with a missing commit error (e.g.
 ```
 fatal: remote error: upload-pack: not our ref 5700a7c74927d2c4912ac95e904c6ad3642b6868
-Fetched in submodule path 'libs/quiche-patched', but it did not contain 5700a7c74927d2c4912ac95e904c6ad3642b6868.
+Fetched in submodule path 'libs/patched_quiche/quiche', but it did not contain 5700a7c74927d2c4912ac95e904c6ad3642b6868.
 ```
 ), the upstream `quiche` repository might not contain the pinned
 revision `5700a7c74927d2c4912ac95e904c6ad3642b6868`. Update the
 submodule URL to a mirror that includes this commit and retry:
 
 ```bash
-git submodule set-url libs/quiche-patched <mirror-url>
-git submodule update --init libs/quiche-patched
+git submodule set-url libs/patched_quiche/quiche <mirror-url>
+git submodule update --init libs/patched_quiche/quiche
 ```
 
 Alternatively, run the helper script to automatically set the mirror,
@@ -113,7 +113,7 @@ variable to skip fetching and build from that path instead.
 Compile the patched **quiche** library using Cargo:
 
 ```bash
-cd libs/quiche-patched
+cd libs/patched_quiche/quiche
 cargo build --release
 cd ../..
 ```

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -26,8 +26,8 @@
 - `core/quic_connection.hpp`: Include und Variable von ASCON zu MORUS geändert
 - `stealth/browser_profiles/fingerprints/browser_fingerprint.hpp`: Cipher Suite Liste aktualisiert
 - `stealth/tls/FakeTLS.hpp`, `stealth/tls/FakeTLS.cpp`, `stealth/tls/uTLS.cpp`: TLS-Fingerprinting angepasst
-- `libs/quiche-patched/src/crypto.rs`: Algorithm enum und alle Referenzen aktualisiert
-- `libs/quiche-patched/src/tls.rs`: TLS-Cipher-Mapping aktualisiert
+- `libs/patched_quiche/quiche/src/crypto.rs`: Algorithm enum und alle Referenzen aktualisiert
+- `libs/patched_quiche/quiche/src/tls.rs`: TLS-Cipher-Mapping aktualisiert
 - `DOCUMENTATION.md`: Vollständige Dokumentation überarbeitet
 
 ### 📝 Technische Details

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -31,7 +31,7 @@ QuicFuscate/
 ├── docs/
 │   └── DOCUMENTATION.md
 ├── libs/
-│   └── quiche-patched/
+│   └── patched_quiche/
 └── ui/
     └── logo/
 ```

--- a/scripts/fetch_quiche.sh
+++ b/scripts/fetch_quiche.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fetch or reuse a patched quiche source tree.
+# Usage: ./scripts/fetch_quiche.sh [mirror-url]
+# Optional environment variables:
+#   QUICHE_PATH  Use an existing local quiche checkout instead of cloning.
+#   QUICHE_COMMIT  Commit hash to checkout (defaults to pinned revision).
+#
+
+MIRROR_URL=${1:-""}
+QUICHE_REPO=${MIRROR_URL:-"https://github.com/cloudflare/quiche.git"}
+QUICHE_COMMIT=${QUICHE_COMMIT:-"5700a7c74927d2c4912ac95e904c6ad3642b6868"}
+DEST_DIR="libs/patched_quiche/quiche"
+
+if [ -n "${QUICHE_PATH:-}" ]; then
+    echo "Using local quiche from $QUICHE_PATH"
+    rm -rf "$DEST_DIR"
+    mkdir -p "$(dirname "$DEST_DIR")"
+    cp -R "$QUICHE_PATH" "$DEST_DIR"
+else
+    if [ -d "$DEST_DIR/.git" ]; then
+        git -C "$DEST_DIR" fetch --depth 1 "$QUICHE_REPO" "$QUICHE_COMMIT"
+    else
+        rm -rf "$DEST_DIR"
+        git clone --depth 1 "$QUICHE_REPO" "$DEST_DIR"
+    fi
+    git -C "$DEST_DIR" checkout "$QUICHE_COMMIT"
+fi
+
+pushd "$DEST_DIR" > /dev/null
+cargo build --release
+popd > /dev/null


### PR DESCRIPTION
## Summary
- add `scripts/fetch_quiche.sh` to download patched `quiche`
- update references to `libs/patched_quiche` in docs
- fix `Cargo.toml` path to the `quiche` crate

## Testing
- `QUICHE_COMMIT=$(git -C libs/patched_quiche/quiche rev-parse HEAD) bash scripts/fetch_quiche.sh`
- `cargo test --workspace --all-targets` *(fails: failed to select a version for `aegis`)*

------
https://chatgpt.com/codex/tasks/task_e_6868279982848333b44e9f9612b97540