### PR TITLE
Restore quiche fetch script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aligned_box = "0.2"
-quiche = { path = "libs/patched_quiche/quiche/quiche" }
+quiche = { path = "libs/patched_quiche/quiche" }
 rustls = "0.22.2"
 aegis = { version = "0.9.0", features = ["aegis-128x"] }
 morus = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -80,21 +80,21 @@ cloning using one of the methods below.
 After cloning the project, initialize the submodule with:
 
 ```bash
-git submodule update --init --recursive libs/patched_quiche/quiche
+git submodule update --init --recursive libs/patched_quiche
 ```
 
 If the command fails with a missing commit error (e.g.
 ```
 fatal: remote error: upload-pack: not our ref 5700a7c74927d2c4912ac95e904c6ad3642b6868
-Fetched in submodule path 'libs/patched_quiche/quiche', but it did not contain 5700a7c74927d2c4912ac95e904c6ad3642b6868.
+Fetched in submodule path 'libs/patched_quiche', but it did not contain 5700a7c74927d2c4912ac95e904c6ad3642b6868.
 ```
 ), the upstream `quiche` repository might not contain the pinned
 revision `5700a7c74927d2c4912ac95e904c6ad3642b6868`. Update the
 submodule URL to a mirror that includes this commit and retry:
 
 ```bash
-git submodule set-url libs/patched_quiche/quiche <mirror-url>
-git submodule update --init libs/patched_quiche/quiche
+git submodule set-url libs/patched_quiche <mirror-url>
+git submodule update --init libs/patched_quiche
 ```
 
 Alternatively, run the helper script to automatically set the mirror,
@@ -113,9 +113,9 @@ variable to skip fetching and build from that path instead.
 Compile the patched **quiche** library using Cargo:
 
 ```bash
-cd libs/patched_quiche/quiche
+cd libs/patched_quiche
 cargo build --release
-cd ../..
+cd ..
 ```
 
 ### Building

--- a/scripts/fetch_quiche.sh
+++ b/scripts/fetch_quiche.sh
@@ -1,33 +1,34 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -e
 
-# Fetch or reuse a patched quiche source tree.
-# Usage: ./scripts/fetch_quiche.sh [mirror-url]
-# Optional environment variables:
-#   QUICHE_PATH  Use an existing local quiche checkout instead of cloning.
-#   QUICHE_COMMIT  Commit hash to checkout (defaults to pinned revision).
-#
+MIRROR_URL=${1:-https://github.com/cloudflare/quiche.git}
+SUBMODULE_PATH="libs/patched_quiche"
 
-MIRROR_URL=${1:-""}
-QUICHE_REPO=${MIRROR_URL:-"https://github.com/cloudflare/quiche.git"}
-QUICHE_COMMIT=${QUICHE_COMMIT:-"5700a7c74927d2c4912ac95e904c6ad3642b6868"}
-DEST_DIR="libs/patched_quiche/quiche"
-
-if [ -n "${QUICHE_PATH:-}" ]; then
+if [ -n "$QUICHE_PATH" ] && [ -d "$QUICHE_PATH" ]; then
     echo "Using local quiche from $QUICHE_PATH"
-    rm -rf "$DEST_DIR"
-    mkdir -p "$(dirname "$DEST_DIR")"
-    cp -R "$QUICHE_PATH" "$DEST_DIR"
-else
-    if [ -d "$DEST_DIR/.git" ]; then
-        git -C "$DEST_DIR" fetch --depth 1 "$QUICHE_REPO" "$QUICHE_COMMIT"
-    else
-        rm -rf "$DEST_DIR"
-        git clone --depth 1 "$QUICHE_REPO" "$DEST_DIR"
-    fi
-    git -C "$DEST_DIR" checkout "$QUICHE_COMMIT"
+    cd "$QUICHE_PATH"
+    cargo build --release
+    cargo clippy --all-targets -- -D warnings
+    exit 0
 fi
 
-pushd "$DEST_DIR" > /dev/null
+if [ ! -d "$SUBMODULE_PATH" ]; then
+    mkdir -p "$SUBMODULE_PATH"
+fi
+
+echo "Fetching quiche from $MIRROR_URL ..."
+
+if [ -f .gitmodules ] && grep -q "$SUBMODULE_PATH" .gitmodules; then
+    git submodule set-url "$SUBMODULE_PATH" "$MIRROR_URL"
+    git submodule update --init --recursive "$SUBMODULE_PATH"
+else
+    if [ ! -d "$SUBMODULE_PATH/.git" ]; then
+        git clone "$MIRROR_URL" "$SUBMODULE_PATH"
+    else
+        git -C "$SUBMODULE_PATH" pull
+    fi
+fi
+
+cd "$SUBMODULE_PATH"
 cargo build --release
-popd > /dev/null
+cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Summary
- restore `scripts/fetch_quiche.sh` from earlier commit
- update `SUBMODULE_PATH` to `libs/patched_quiche`
- fix Cargo path for the local quiche crate
- adjust README instructions for the new path

## Testing
- `cargo test --workspace --quiet` *(fails: failed to select a version for `aegis`)*

------
https://chatgpt.com/codex/tasks/task_e_68682eed367c8333b3d3862e79d3270a