### PR TITLE
Add SIMD & Rayon paths with extreme-mode tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,5 @@ crossbeam-queue = "0.3"
 libc = "0.2"
 prometheus = "0.13"
 hyper = { version = "0.14", features = ["full"] }
+rayon = "1.9"
 

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -36,6 +36,7 @@
 //! It also includes foundational structures for zero-copy operations and memory pooling.
 
 use aligned_box::{AlignedBox, MIN_ALIGN};
+use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, Once};
 use log::info;
@@ -117,27 +118,49 @@ impl FeatureDetector {
 //
 
 /// Represents the execution policy for SIMD operations.
-pub trait SimdPolicy {}
+pub trait SimdPolicy: Any {
+    fn as_any(&self) -> &dyn Any;
+}
 
 /// Marker struct for AVX-512 execution.
 pub struct Avx512;
-impl SimdPolicy for Avx512 {}
+impl SimdPolicy for Avx512 {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 /// Marker struct for AVX2 execution.
 pub struct Avx2;
-impl SimdPolicy for Avx2 {}
+impl SimdPolicy for Avx2 {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 /// Marker struct for PCLMULQDQ execution.
 pub struct Pclmulqdq;
-impl SimdPolicy for Pclmulqdq {}
+impl SimdPolicy for Pclmulqdq {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 /// Marker struct for ARM NEON execution.
 pub struct Neon;
-impl SimdPolicy for Neon {}
+impl SimdPolicy for Neon {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 /// Marker struct for scalar (non-SIMD) execution.
 pub struct Scalar;
-impl SimdPolicy for Scalar {}
+impl SimdPolicy for Scalar {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
 
 /// Dispatches to the best available SIMD implementation at runtime.
 /// The policies are ordered from most to least performant.


### PR DESCRIPTION
## Summary
- enable Rayon in dependencies
- expose SIMD policies for downcasting
- parallelize FEC repair generation when AVX2/NEON is available
- expose FEC state helpers and add tests for extreme mode and cross‑fade

## Testing
- `cargo test --quiet` *(fails: failed to get `quiche` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686833bc06888333a5600317198a13cb