### PR TITLE
Enable configurable FEC window sizes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ prometheus = "0.13"
 hyper = { version = "0.14", features = ["full"] }
 sha2 = "0.10"
 rayon = "1.9"
+toml = "0.8"

--- a/src/core.rs
+++ b/src/core.rs
@@ -174,6 +174,7 @@ impl QuicFuscateConnection {
                 ki: 0.1,
                 kd: 0.2,
             },
+            window_sizes: FecConfig::default_windows(),
         };
 
         Self {


### PR DESCRIPTION
## Summary
- allow FEC configuration via TOML
- support per-mode sliding window sizes
- expose new `FecConfig::default_windows()` and `from_toml`
- update `ModeManager` to use configurable windows
- add recovery and config parsing tests

## Testing
- `cargo test --lib` *(fails: failed to get `quiche` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686841f68c008333b911dc385fb9900f