### PR TITLE
Add TLS FFI shim and StealthManager unit tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod fec;
 pub mod optimize;
 pub mod stealth;
 pub mod xdp_socket;
+pub mod tls_ffi;
 
 pub use optimize::{CpuFeature, FeatureDetector};
 

--- a/src/tls_ffi.rs
+++ b/src/tls_ffi.rs
@@ -1,0 +1,16 @@
+use std::os::raw::c_void;
+
+/// FFI shim for injecting a custom TLS ClientHello into quiche.
+///
+/// Builds without the patched quiche library provide a no-op
+/// implementation so that tests can run. When linked against a
+/// modified quiche with support for custom ClientHello messages the
+/// symbol will be overridden by the real implementation.
+#[no_mangle]
+pub unsafe extern "C" fn quiche_config_set_custom_tls(
+    _cfg: *mut c_void,
+    _hello: *const u8,
+    _len: usize,
+) {
+    log::debug!("quiche_config_set_custom_tls stub invoked");
+}

--- a/tests/stealth.rs
+++ b/tests/stealth.rs
@@ -1,0 +1,57 @@
+use quicfuscate::crypto::CryptoManager;
+use quicfuscate::optimize::OptimizationManager;
+use quicfuscate::stealth::{StealthConfig, StealthManager};
+use std::sync::Arc;
+
+#[test]
+fn outgoing_packet_obfuscation_cycle() {
+    let crypto = Arc::new(CryptoManager::new());
+    let optimize = Arc::new(OptimizationManager::new());
+    let config = StealthConfig::default();
+    let mgr = StealthManager::new(config, crypto, optimize);
+
+    let mut payload = vec![1u8, 2, 3, 4];
+    let original = payload.clone();
+    mgr.process_outgoing_packet(&mut payload);
+    assert_ne!(payload, original, "payload should be obfuscated");
+    mgr.process_incoming_packet(&mut payload);
+    assert_eq!(payload, original, "payload should roundtrip correctly");
+}
+
+#[test]
+fn domain_fronting_changes_sni() {
+    let crypto = Arc::new(CryptoManager::new());
+    let optimize = Arc::new(OptimizationManager::new());
+    let mut config = StealthConfig::default();
+    config.enable_domain_fronting = true;
+    let mgr = StealthManager::new(config, crypto, optimize);
+
+    let (sni, host) = mgr.get_connection_headers("example.com");
+    assert_eq!(host, "example.com");
+    assert_ne!(sni, host, "SNI should differ when fronting is enabled");
+}
+
+#[test]
+fn generate_http3_headers() {
+    let crypto = Arc::new(CryptoManager::new());
+    let optimize = Arc::new(OptimizationManager::new());
+    let config = StealthConfig::default();
+    let mgr = StealthManager::new(config, crypto, optimize);
+
+    let headers = mgr
+        .get_http3_masquerade_headers("example.com", "/")
+        .expect("headers");
+    assert!(!headers.is_empty());
+}
+
+#[test]
+fn doh_disabled_fallback() {
+    let crypto = Arc::new(CryptoManager::new());
+    let optimize = Arc::new(OptimizationManager::new());
+    let mut config = StealthConfig::default();
+    config.enable_doh = false;
+    let mgr = StealthManager::new(config, crypto, optimize);
+
+    let ip = mgr.resolve_domain("example.com");
+    assert_eq!(ip.to_string(), "1.1.1.1");
+}


### PR DESCRIPTION
## Summary
- expose a stub `quiche_config_set_custom_tls` FFI to allow custom ClientHello injection
- export the new module in `lib.rs`
- add unit tests covering `StealthManager` features

## Testing
- `cargo test` *(fails: failed to get `quiche` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68690ff7e1808333a79225bef99466f6