### PR TITLE
Add patch directory and integrate patch step

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -58,10 +58,20 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-
     
-    - name: Run Quiche Workflow
+    - name: fetch_quiche
       run: |
         chmod +x ./scripts/quiche_workflow.sh
-        ./scripts/quiche_workflow.sh --type ${{ inputs.build_type || 'release' }}
+        ./scripts/quiche_workflow.sh --step fetch
+
+    - name: apply_patches
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step patch
+
+    - name: build_quiche
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
     
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4

--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -23,14 +23,14 @@ This document consolidates all information regarding the integration, optimizati
 
 2. **Code Organization**
    ```
-   QuicFuscate/
-   ├── libs/
-   │   └── patched_quiche/      # Customized quiche version
-   │       ├── quiche/          # quiche source code
-   │       └── patches/         # Applied patches
-   ├── scripts/                 # Automation scripts
-   └── docs/                    # Documentation
-   ```
+  QuicFuscate/
+  ├── libs/
+  │   ├── patched_quiche/      # Customized quiche version
+  │   ├── vanilla_quiche/      # Upstream quiche source
+  │   └── patches/             # *.patch files
+  ├── scripts/                 # Automation scripts
+  └── docs/                    # Documentation
+  ```
 
 3. **Technical Guidelines**
    - Only make compatibility changes to quiche
@@ -134,7 +134,7 @@ QuicFuscate includes a GitHub Actions workflow for automated building and testin
 2. **Build Process**
    - Executes the quiche workflow script
    - Supports both release and debug builds
-   - Applies all patches from `libs/patches/`
+  - Applies all patches from `libs/patches/*.patch`
 
 3. **Artifact Handling**
    - Packages the built artifacts
@@ -171,7 +171,7 @@ The `scripts/quiche_workflow.sh` script provides a complete local development wo
    # Fetch the latest quiche version
    ./scripts/fetch_quiche.sh
 
-   # Apply custom patches
+   # Apply custom patches from libs/patches/*.patch
    ./scripts/apply_patches.sh
 
    # Test the updated version

--- a/libs/patches/readme_quicfuscate.patch
+++ b/libs/patches/readme_quicfuscate.patch
@@ -1,0 +1,10 @@
+--- a/README.md
++++ b/README.md
+@@
+ [![docs.rs](https://docs.rs/quiche/badge.svg)](https://docs.rs/quiche)
+ [![license](https://img.shields.io/github/license/cloudflare/quiche.svg)](https://opensource.org/licenses/BSD-2-Clause)
+ ![build](https://img.shields.io/github/actions/workflow/status/cloudflare/quiche/stable.yml?branch=master)
++
++Patched by QuicFuscate.
+ 
+ [quiche] is an implementation of the QUIC transport protocol and HTTP/3 as

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -33,6 +33,7 @@ BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIBS_DIR="$BASE_DIR/libs"
 VANILLA_DIR="$LIBS_DIR/vanilla_quiche"
 PATCHED_DIR="$LIBS_DIR/patched_quiche"
+# Directory containing patch files (*.patch)
 PATCHES_DIR="$LIBS_DIR/patches"
 LOG_DIR="$LIBS_DIR/logs"
 STATE_FILE="$BASE_DIR/.quiche_workflow_state"


### PR DESCRIPTION
## Summary
- introduce `libs/patches` to hold patch files
- document new patch location in `Quiche_Dependency.md`
- note manual patch step path
- make patch path explicit in `quiche_workflow.sh`
- call patch step separately in GitHub Actions workflow

## Testing
- `cargo test --workspace --all-targets` *(fails: failed to load quiche dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa44dbc48333ac2bb7b887eae5c3