### PR TITLE
Initialize quiche submodule in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Verify submodules
+        shell: bash
+        run: |
+          if [ ! -d libs/patched_quiche ]; then
+            echo "libs/patched_quiche missing" >&2
+            exit 1
+          fi
+
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -37,7 +45,7 @@ jobs:
       - name: Fetch and build quiche
         shell: bash
         run: |
-          ./scripts/fetch_quiche.sh
+          ./scripts/quiche_workflow.sh --step fetch
 
       - name: Run Clippy
         shell: bash

--- a/README.md
+++ b/README.md
@@ -73,13 +73,21 @@ The codebase is now entirely written in Rust. Development focuses on expanding f
 ## 🔧 Build Instructions
 
 This repository uses a Git submodule to include a patched QUIC library.
-The `libs/patched_quiche` directory is intentionally left empty in the
-repository to avoid bloating the checkout size. Fetch the sources after
-cloning using one of the methods below.
-After cloning the project, initialize the submodule with:
+The `libs/patched_quiche` directory is intentionally left empty to keep the
+checkout small. Fetch the sources after cloning by running the workflow
+script below.
+After cloning simply run the workflow script which fetches the sources and
+initializes the submodule automatically:
 
 ```bash
-git submodule update --init --recursive libs/patched_quiche
+./scripts/quiche_workflow.sh --step fetch
+```
+
+Quick start after cloning:
+
+```bash
+./scripts/quiche_workflow.sh --step fetch
+cargo build --workspace --release
 ```
 
 If the command fails with a missing commit error (e.g.
@@ -93,19 +101,12 @@ submodule URL to a mirror that includes this commit and retry:
 
 ```bash
 git submodule set-url libs/patched_quiche <mirror-url>
-git submodule update --init libs/patched_quiche
+./scripts/quiche_workflow.sh --step fetch
 ```
 
-Alternatively, run the helper script to automatically set the mirror,
-fetch the sources and build the library in one step (optionally pass a
-mirror URL):
-
-```bash
-./scripts/fetch_quiche.sh [mirror-url]
-```
-
-If a local copy of quiche already exists, set the `QUICHE_PATH` environment
-variable to skip fetching and build from that path instead.
+The workflow script replaces the old `fetch_quiche.sh` helper and can be
+re-run at any time. If a local copy of quiche already exists, set the
+`QUICHE_PATH` environment variable to use that path instead.
 
 ### Building quiche
 

--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -12,6 +12,17 @@
 
 This document consolidates all information regarding the integration, optimization, and maintenance of the quiche library within the QuicFuscate project. The quiche library serves as the foundation for QUIC protocol implementation, specifically tailored for QuicFuscate's requirements.
 
+## Quick Start
+
+Clone the repository, run the workflow to fetch quiche and build the project:
+
+```bash
+./scripts/quiche_workflow.sh --step fetch
+cargo build --workspace --release
+```
+
+The `fetch` step initializes the `libs/patched_quiche` submodule automatically.
+
 ## Integration Guidelines
 
 ### Core Principles
@@ -168,8 +179,8 @@ The `scripts/quiche_workflow.sh` script provides a complete local development wo
 
 2. **Manual Process** (if needed):
    ```bash
-   # Fetch the latest quiche version
-   ./scripts/fetch_quiche.sh
+   # Fetch the latest quiche version and initialize the submodule
+   ./scripts/quiche_workflow.sh --step fetch
 
    # Apply custom patches
    ./scripts/apply_patches.sh

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -31,7 +31,6 @@ error() {
 # Konfiguration
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 LIBS_DIR="$BASE_DIR/libs"
-VANILLA_DIR="$LIBS_DIR/vanilla_quiche"
 PATCHED_DIR="$LIBS_DIR/patched_quiche"
 PATCHES_DIR="$LIBS_DIR/patches"
 LOG_DIR="$LIBS_DIR/logs"
@@ -40,7 +39,7 @@ BUILD_TYPE="release"
 MIRROR_URL="https://github.com/cloudflare/quiche.git"
 
 # Erstelle benötigte Verzeichnisse
-mkdir -p "$LOG_DIR" "$PATCHES_DIR" "$VANILLA_DIR" "$PATCHED_DIR"
+mkdir -p "$LOG_DIR" "$PATCHES_DIR" "$PATCHED_DIR"
 
 # Lade den aktuellen Status
 load_state() {
@@ -89,27 +88,24 @@ fetch_quiche() {
     
     log "Starte Herunterladen von quiche..."
     log "Quelle: $MIRROR_URL"
-    log "Ziel: $VANILLA_DIR"
-    
-    # Lösche vorhandene Inhalte, falls vorhanden
-    rm -rf "$VANILLA_DIR" "$PATCHED_DIR"
-    
-    # Erstelle die Verzeichnisse neu
-    mkdir -p "$VANILLA_DIR" "$PATCHED_DIR"
-    
-    # Klone die neueste Version
-    if [ -d "$VANILLA_DIR/.git" ]; then
+    log "Ziel: $PATCHED_DIR"
+
+    mkdir -p "$PATCHED_DIR"
+
+    if git -C "$BASE_DIR" submodule status libs/patched_quiche >/dev/null 2>&1; then
+        log "Initialisiere Submodul libs/patched_quiche..."
+        run_command "Submodul aktualisieren" \
+            "git submodule set-url libs/patched_quiche \"$MIRROR_URL\" && git submodule update --init libs/patched_quiche"
+    fi
+
+    if [ -e "$PATCHED_DIR/.git" ]; then
         log "Repository existiert bereits, aktualisiere..."
         run_command "Aktualisieren des Quiche-Repositories" \
-            "(cd \"$VANILLA_DIR\" && git fetch --all && git reset --hard origin/HEAD)"
+            "(cd \"$PATCHED_DIR\" && git fetch --all && git reset --hard origin/HEAD)"
     else
         run_command "Klonen des Quiche-Repositories" \
-            "git clone --depth 1 \"$MIRROR_URL\" \"$VANILLA_DIR\""
+            "git clone --depth 1 \"$MIRROR_URL\" \"$PATCHED_DIR\""
     fi
-    
-    # Kopiere die unveränderte Version in das gepatchte Verzeichnis
-    run_command "Erstellen der Arbeitskopie" \
-        "cp -r \"$VANILLA_DIR/\"* \"$PATCHED_DIR/\""
     
     success "Quiche erfolgreich heruntergeladen und vorbereitet"
     return 0


### PR DESCRIPTION
## Summary
- init quiche submodule automatically in `quiche_workflow.sh`
- describe clone → workflow → build procedure in README and docs
- fail CI if submodule is missing and use workflow script for fetching

## Testing
- `./scripts/quiche_workflow.sh --step fetch`
- `cargo test --workspace --all-targets` *(fails: CMake Error: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_6869aa4d00ec83338930d7c6fd02da9c