### PR TITLE
Implement pooled memory buffers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ async fn run_client(
         // Process incoming packets
         match socket.recv(&mut buf) {
             Ok(len) => {
-                let _ = conn.recv(&mut buf[..len]);
+                let _ = conn.recv(&buf[..len]);
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
             Err(e) => {
@@ -423,7 +423,7 @@ async fn run_server(
                     .expect("failed to create server connection")
                 });
 
-                if let Err(e) = client_conn.recv(&mut buf[..len]) {
+                if let Err(e) = client_conn.recv(&buf[..len]) {
                     error!("QUIC recv failed: {:?}", e);
                     continue;
                 }

--- a/tests/optimize.rs
+++ b/tests/optimize.rs
@@ -12,6 +12,17 @@ fn memory_pool_alloc_free() {
 }
 
 #[test]
+fn memory_pool_reuse() {
+    let pool = MemoryPool::new(1, 64);
+    let block = pool.alloc();
+    let ptr = block.as_ptr();
+    pool.free(block);
+    let block2 = pool.alloc();
+    assert_eq!(ptr, block2.as_ptr());
+    pool.free(block2);
+}
+
+#[test]
 fn xdp_socket_creation() {
     let mgr = OptimizationManager::new();
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();


### PR DESCRIPTION
## Summary
- finalize the `MemoryPool` by adding a `from_block` constructor for FEC packets
- use pooled blocks in `recv` for zero-copy behaviour
- adjust call sites in `main.rs`
- add a test ensuring memory pool reuse

## Testing
- `cargo test --quiet` *(fails: unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_6869aacf17e883339a1aad592c3ad0e3