### PR TITLE
Add dynamic memory pooling and FEC buffer cleanup

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -297,6 +297,7 @@ impl QuicFuscateConnection {
             len: write,
             is_systematic: true,
             coefficients: None,
+            coeff_len: 0,
             mem_pool: self.optimization_manager.memory_pool(),
         };
         self.packet_id_counter += 1;

--- a/src/fec.rs
+++ b/src/fec.rs
@@ -257,7 +257,8 @@ pub struct Packet {
     pub data: Option<AlignedBox<[u8]>>,
     pub len: usize,
     pub is_systematic: bool,
-    pub coefficients: Option<Vec<u8>>, // Present only in repair packets
+    pub coefficients: Option<AlignedBox<[u8]>>,
+    pub coeff_len: usize,
     mem_pool: Arc<MemoryPool>,
 }
 
@@ -277,7 +278,7 @@ impl Packet {
         let is_systematic = raw_data[0] == 1;
         let mut offset = 1;
 
-        let (coefficients, payload_offset) = if !is_systematic {
+        let (coefficients, coeff_len, payload_offset) = if !is_systematic {
             if raw_data.len() < 3 {
                 return Err("Buffer too short for coefficient length".to_string());
             }
@@ -288,10 +289,11 @@ impl Packet {
             if raw_data.len() < offset + coeff_len {
                 return Err("Buffer too short for coefficients".to_string());
             }
-            let coeffs = raw_data[offset..offset + coeff_len].to_vec();
-            (Some(coeffs), offset + coeff_len)
+            let mut coeff_block = opt_manager.alloc_block();
+            coeff_block[..coeff_len].copy_from_slice(&raw_data[offset..offset + coeff_len]);
+            (Some(coeff_block), coeff_len, offset + coeff_len)
         } else {
-            (None, offset)
+            (None, 0, offset)
         };
 
         let payload = &raw_data[payload_offset..];
@@ -307,6 +309,7 @@ impl Packet {
             len: payload.len(),
             is_systematic,
             coefficients,
+            coeff_len,
             mem_pool: opt_manager.memory_pool(),
         })
     }
@@ -327,7 +330,7 @@ impl Packet {
         let is_systematic = block[0] == 1;
         let mut offset = 1;
 
-        let (coefficients, payload_offset) = if !is_systematic {
+        let (coefficients, coeff_len, payload_offset) = if !is_systematic {
             if len < 3 {
                 opt_manager.free_block(block);
                 return Err("Buffer too short for coefficient length".to_string());
@@ -338,10 +341,11 @@ impl Packet {
                 opt_manager.free_block(block);
                 return Err("Buffer too short for coefficients".to_string());
             }
-            let coeffs = block[offset..offset + coeff_len].to_vec();
-            (Some(coeffs), offset + coeff_len)
+            let mut coeff_block = opt_manager.alloc_block();
+            coeff_block[..coeff_len].copy_from_slice(&block[offset..offset + coeff_len]);
+            (Some(coeff_block), coeff_len, offset + coeff_len)
         } else {
-            (None, offset)
+            (None, 0, offset)
         };
 
         let payload_len = len - payload_offset;
@@ -355,6 +359,7 @@ impl Packet {
             len: payload_len,
             is_systematic,
             coefficients,
+            coeff_len,
             mem_pool: opt_manager.memory_pool(),
         })
     }
@@ -362,8 +367,8 @@ impl Packet {
     /// Serializes the packet into a raw byte buffer for transmission.
     pub fn to_raw(&self, buffer: &mut [u8]) -> Result<usize, quiche::Error> {
         let mut required_len = self.len + 1;
-        if let Some(coeffs) = &self.coefficients {
-            required_len += 2 + coeffs.len();
+        if let Some(_) = &self.coefficients {
+            required_len += 2 + self.coeff_len;
         }
         if buffer.len() < required_len {
             return Err(quiche::Error::BufferTooShort);
@@ -374,11 +379,12 @@ impl Packet {
         offset += 1;
 
         if let Some(coeffs) = &self.coefficients {
-            let coeff_len = coeffs.len() as u16;
+            let coeff_len = self.coeff_len as u16;
             buffer[offset..offset + 2].copy_from_slice(&coeff_len.to_be_bytes());
             offset += 2;
-            buffer[offset..offset + coeffs.len()].copy_from_slice(coeffs);
-            offset += coeffs.len();
+            buffer[offset..offset + self.coeff_len]
+                .copy_from_slice(&coeffs[..self.coeff_len]);
+            offset += self.coeff_len;
         }
 
         if let Some(ref data) = self.data {
@@ -401,7 +407,12 @@ impl Packet {
             data: Some(new_data),
             len: self.len,
             is_systematic: self.is_systematic,
-            coefficients: self.coefficients.clone(),
+            coefficients: self.coefficients.as_ref().map(|c| {
+                let mut nb = mem_pool.alloc();
+                nb[..self.coeff_len].copy_from_slice(&c[..self.coeff_len]);
+                nb
+            }),
+            coeff_len: self.coeff_len,
             mem_pool: Arc::clone(mem_pool),
         }
     }
@@ -411,6 +422,9 @@ impl Drop for Packet {
     fn drop(&mut self) {
         if let Some(data) = self.data.take() {
             self.mem_pool.free(data);
+        }
+        if let Some(coeffs) = self.coefficients.take() {
+            self.mem_pool.free(coeffs);
         }
     }
 }
@@ -732,13 +746,20 @@ impl Encoder16 {
                 j += 2;
             }
         }
-        let coeff_bytes: Vec<u8> = coeffs.iter().flat_map(|c| c.to_be_bytes()).collect();
+        let mut coeff_block = mem_pool.alloc();
+        for (i, c) in coeffs.iter().enumerate() {
+            let bytes = c.to_be_bytes();
+            coeff_block[2 * i] = bytes[0];
+            coeff_block[2 * i + 1] = bytes[1];
+        }
         Some(Packet {
             id: self.source_window.back().unwrap().id + 1 + repair_packet_index as u64,
             data: repair_data,
             len: packet_len,
             is_systematic: false,
-            coefficients: Some(coeff_bytes),
+            coefficients: Some(coeff_block),
+            coeff_len: coeffs.len() * 2,
+            mem_pool: Arc::clone(mem_pool),
         })
     }
 
@@ -881,12 +902,15 @@ impl Encoder {
             }
         });
 
+        let mut coeff_block = mem_pool.alloc();
+        coeff_block[..coeffs.len()].copy_from_slice(&coeffs);
         Some(Packet {
             id: self.source_window.back().unwrap().id + 1 + repair_packet_index as u64,
             data: Some(repair_data),
             len: packet_len,
             is_systematic: false,
-            coefficients: Some(coeffs),
+            coefficients: Some(coeff_block),
+            coeff_len: coeffs.len(),
             mem_pool: Arc::clone(mem_pool),
         })
     }
@@ -1088,8 +1112,8 @@ impl Decoder16 {
         } else if let Some(c) = packet.coefficients {
             let mut row = Vec::with_capacity(self.k);
             for i in 0..self.k {
-                let hi = c[2*i];
-                let lo = c[2*i+1];
+                let hi = c[2 * i];
+                let lo = c[2 * i + 1];
                 row.push(u16::from_be_bytes([hi, lo]));
             }
             self.matrix.push(row);
@@ -1161,7 +1185,7 @@ impl Decoder {
             return Ok(self.is_decoded);
         }
 
-        let (coeffs, packet_data_owned) = if packet.is_systematic {
+        if packet.is_systematic {
             let index = (packet.id as usize) % self.k;
             let mut identity_row = vec![0; self.k];
             identity_row[index] = 1;
@@ -1170,15 +1194,14 @@ impl Decoder {
             } else {
                 return Ok(self.is_decoded); // Duplicate packet
             }
-            (identity_row, None) // Systematic data is stored directly
+            self.decoding_matrix.append_row(&identity_row, None);
+            Ok(self.try_decode())
         } else if let Some(coeffs) = packet.coefficients {
-            (coeffs, packet.data) // Repair packet provides data
+            self.decoding_matrix.append_row(&coeffs[..packet.coeff_len], packet.data);
+            Ok(self.try_decode())
         } else {
-            return Err("Repair packet missing coefficients.");
-        };
-
-        self.decoding_matrix.append_row(&coeffs, packet_data_owned);
-        Ok(self.try_decode())
+            Err("Repair packet missing coefficients.")
+        }
     }
 
     /// Attempts to decode once enough packets (K) have been received.


### PR DESCRIPTION
## Summary
- implement `MemoryPool` with mutex protection and runtime capacity control
- extend `ZeroCopyBuffer` with `Drop` and helper methods
- store FEC packet coefficients in pooled buffers
- adapt core connection to new FEC packet fields

## Testing
- `cargo check` *(fails: source directory for boringssl does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6869b36089e88333bcb7afb29a117d50