### PR TITLE
Finalize FEC implementation with SIMD matrix ops

### DIFF
--- a/tests/fec.rs
+++ b/tests/fec.rs
@@ -1,0 +1,92 @@
+use quicfuscate::fec::{AdaptiveFec, Decoder, Decoder16, Encoder, Encoder16, FecConfig, FecMode};
+use quicfuscate::optimize::MemoryPool;
+use std::sync::Arc;
+
+fn make_packet(id: u64, val: u8, pool: &Arc<MemoryPool>) -> quicfuscate::fec::Packet {
+    let mut buf = pool.alloc();
+    for b in buf.iter_mut().take(8) {
+        *b = val;
+    }
+    quicfuscate::fec::Packet {
+        id,
+        data: Some(buf),
+        len: 8,
+        is_systematic: true,
+        coefficients: None,
+        mem_pool: Arc::clone(pool),
+    }
+}
+
+#[test]
+fn gf8_encode_decode() {
+    quicfuscate::fec::init_gf_tables();
+    let pool = Arc::new(MemoryPool::new(32, 64));
+    let k = 4;
+    let n = 6;
+    let mut enc = Encoder::new(k, n);
+    let mut packets = Vec::new();
+    for i in 0..k {
+        let p = make_packet(i as u64, i as u8, &pool);
+        enc.add_source_packet(p.clone());
+        packets.push(p);
+    }
+    let mut repairs = Vec::new();
+    for i in 0..(n - k) {
+        repairs.push(enc.generate_repair_packet(i, &pool).unwrap());
+    }
+    let mut dec = Decoder::new(k, Arc::clone(&pool));
+    dec.add_packet(packets[0].clone()).unwrap();
+    dec.add_packet(packets[2].clone()).unwrap();
+    dec.add_packet(packets[3].clone()).unwrap();
+    for r in repairs {
+        dec.add_packet(r).unwrap();
+    }
+    assert!(dec.is_decoded);
+    let out = dec.get_decoded_packets();
+    assert_eq!(out.len(), k);
+    for i in 0..k {
+        assert_eq!(out[i].data.as_ref().unwrap()[0], i as u8);
+    }
+}
+
+#[test]
+fn gf16_encode_decode() {
+    quicfuscate::fec::init_gf_tables();
+    let pool = Arc::new(MemoryPool::new(128, 64));
+    let k = 8;
+    let n = k + 4;
+    let mut enc = Encoder16::new(k, n);
+    let mut packets = Vec::new();
+    for i in 0..k {
+        let p = make_packet(i as u64, (i % 255) as u8, &pool);
+        enc.add_source_packet(p.clone());
+        packets.push(p);
+    }
+    let mut repairs = Vec::new();
+    for i in 0..(n - k) {
+        repairs.push(enc.generate_repair_packet(i, &pool).unwrap());
+    }
+    let mut dec = Decoder16::new(k, Arc::clone(&pool));
+    for pkt in packets.into_iter().skip(1) {
+        dec.add_packet(pkt).unwrap();
+    }
+    for r in repairs {
+        dec.add_packet(r).unwrap();
+    }
+    assert!(dec.is_decoded);
+    let out = dec.get_decoded_packets();
+    assert_eq!(out.len(), k);
+    for i in 0..k {
+        assert_eq!(out[i].data.as_ref().unwrap()[0], (i % 255) as u8);
+    }
+}
+
+#[test]
+fn adaptive_mode_switch_high_loss() {
+    quicfuscate::fec::init_gf_tables();
+    let pool = Arc::new(MemoryPool::new(32, 64));
+    let cfg = FecConfig::default();
+    let mut fec = AdaptiveFec::new(cfg, Arc::clone(&pool));
+    fec.report_loss(40, 50);
+    assert_eq!(fec.current_mode(), FecMode::Extreme);
+}


### PR DESCRIPTION
## Summary
- complete GF(2^16) arithmetic with dispatch wrapper
- speed up matrix scaling/addition using `optimize::dispatch`
- provide new FEC unit tests for GF(2^8) and GF(2^16)

## Testing
- `cargo test --quiet` *(fails: build script for quiche missing boringssl)*

------
https://chatgpt.com/codex/tasks/task_e_6869b36214808333ab9bdd46b99b42d8