### PR TITLE
Implement CLI improvements and graceful shutdown

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,15 @@
+# Usage Examples
+
+## Client
+
+```
+quicfuscate client --remote 203.0.113.1:4433 --local 127.0.0.1:1080 --profile chrome
+```
+
+## Server
+
+```
+quicfuscate server --listen 0.0.0.0:4433 --cert ./server.crt --key ./server.key --profile firefox
+```
+
+Ensure certificate and key are valid PEM files. Use `CTRL+C` to gracefully stop the process.

--- a/src/core.rs
+++ b/src/core.rs
@@ -41,7 +41,7 @@ use crate::optimize::{MemoryPool, OptimizationManager};
 use crate::stealth::{StealthConfig, StealthManager};
 use crate::xdp_socket::XdpSocket;
 use std::collections::VecDeque;
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 /// Represents a single QuicFuscate connection and manages its state.
@@ -82,6 +82,7 @@ impl QuicFuscateConnection {
     /// Creates a new client connection.
     pub fn new_client(
         server_name: &str,
+        local_addr: SocketAddr,
         remote_addr: SocketAddr,
         mut config: quiche::Config,
         stealth_config: StealthConfig,
@@ -103,7 +104,6 @@ impl QuicFuscateConnection {
         stealth_manager.apply_utls_profile(&mut config);
 
         let scid = quiche::ConnectionId::from_ref(&[0; quiche::MAX_CONN_ID_LEN]);
-        let local_addr = SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0));
 
         let (sni, host_header) = stealth_manager.get_connection_headers(server_name);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -27,6 +27,7 @@ async fn client_server_end_to_end() {
     stealth_cfg.enable_domain_fronting = true;
     let mut client_conn = QuicFuscateConnection::new_client(
         "example.com",
+        client_socket.local_addr().unwrap(),
         server_addr,
         client_config,
         stealth_cfg.clone(),


### PR DESCRIPTION
## Summary
- extend CLI with `--remote` and `--local`
- support new parameters in client implementation
- update connection builder API and integration test
- add graceful shutdown via `tokio::signal`
- document usage examples

## Testing
- `cargo test` *(fails: build script for `quiche` missing boringssl)*

------
https://chatgpt.com/codex/tasks/task_e_6869b3651dcc8333a36e7d9e4c36e326