### PR TITLE
Add custom TLS patch integration

### DIFF
--- a/libs/patches/custom_tls.patch
+++ b/libs/patches/custom_tls.patch
@@ -1,0 +1,110 @@
+--- a/quiche/include/quiche.h
++++ b/quiche/include/quiche.h
+@@ -179,6 +179,9 @@
+ 
+ // Enables sending or receiving early data.
+ void quiche_config_enable_early_data(quiche_config *config);
++// Supplies a custom TLS ClientHello message for connection setup.
++void quiche_config_set_custom_tls(quiche_config *cfg,
++                                  const uint8_t *hello, size_t len);
+ 
+ // Configures the list of supported application protocols.
+ int quiche_config_set_application_protos(quiche_config *config,
+--- a/quiche/src/ffi.rs
++++ b/quiche/src/ffi.rs
+@@ -226,6 +226,15 @@
+ }
+ 
+ #[no_mangle]
++pub extern "C" fn quiche_config_set_custom_tls(
++    config: &mut Config, hello: *const u8, len: size_t,
++) {
++    let hello = unsafe { slice::from_raw_parts(hello, len) };
++    config.set_custom_tls(hello);
++}
++
++
++#[no_mangle]
+ /// Corresponds to the `Config::set_application_protos_wire_format` Rust
+ /// function.
+ pub extern "C" fn quiche_config_set_application_protos(
+--- a/quiche/src/lib.rs
++++ b/quiche/src/lib.rs
+@@ -837,6 +837,7 @@
+ 
+     disable_dcid_reuse: bool,
+ 
++    custom_tls: Option<Vec<u8>>,
+     track_unknown_transport_params: Option<usize>,
+ }
+ 
+@@ -909,6 +910,7 @@
+             max_amplification_factor: MAX_AMPLIFICATION_FACTOR,
+ 
+             disable_dcid_reuse: false,
++            custom_tls: None,
+ 
+             track_unknown_transport_params: None,
+         })
+@@ -1043,6 +1045,11 @@
+         self.tls_ctx.set_early_data_enabled(true);
+     }
+ 
++    /// Stores a custom TLS ClientHello message.
++    pub fn set_custom_tls(&mut self, hello: &[u8]) {
++        self.custom_tls = Some(hello.to_vec());
++    }
++
+     /// Configures the list of supported application protocols.
+     ///
+     /// On the client this configures the list of protocols to send to the
+@@ -1946,7 +1953,10 @@
+         scid: &ConnectionId, odcid: Option<&ConnectionId>, local: SocketAddr,
+         peer: SocketAddr, config: &mut Config, is_server: bool,
+     ) -> Result<Connection<F>> {
+-        let tls = config.tls_ctx.new_handshake()?;
++        let mut tls = config.tls_ctx.new_handshake()?;
++        if let Some(ref hello) = config.custom_tls {
++            tls.set_custom_tls(hello.clone());
++        }
+         Connection::with_tls(scid, odcid, local, peer, config, tls, is_server)
+     }
+ 
+--- a/quiche/src/tls/mod.rs
++++ b/quiche/src/tls/mod.rs
+@@ -353,6 +353,7 @@
+     /// SSL_process_quic_post_handshake should be called when whenever
+     /// SSL_provide_quic_data is called to process the provided data.
+     provided_data_outstanding: bool,
++    custom_tls: Option<Vec<u8>>,
+ }
+ 
+ impl Handshake {
+@@ -367,6 +368,7 @@
+         Handshake {
+             ptr,
+             provided_data_outstanding: false,
++            custom_tls: None,
+         }
+     }
+ 
+@@ -387,6 +389,9 @@
+         self.set_quic_early_data_context(b"quiche")?;
+ 
+         self.set_quiet_shutdown(true);
++        if let Some(ref hello) = self.custom_tls {
++            self.provide_data(crypto::Level::Initial, hello)?;
++        }
+ 
+         Ok(())
+     }
+@@ -560,6 +565,9 @@
+     pub fn write_level(&self) -> crypto::Level {
+         unsafe { SSL_quic_write_level(self.as_ptr()) }
+     }
++    pub fn set_custom_tls(&mut self, hello: Vec<u8>) {
++        self.custom_tls = Some(hello);
++    }
+ 
+     pub fn cipher(&self) -> Option<crypto::Algorithm> {
+         let cipher =

--- a/scripts/maintain_quiche.sh
+++ b/scripts/maintain_quiche.sh
@@ -12,7 +12,7 @@ NC='\033[0m' # No Color
 # Pfade
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 QUICHE_DIR="${SCRIPT_DIR}/../libs/patched_quiche"
-PATCH_DIR="${SCRIPT_DIR}/../patches"
+PATCH_DIR="${SCRIPT_DIR}/../libs/patches"
 
 # Hilfsfunktionen
 log() {


### PR DESCRIPTION
## Summary
- add `custom_tls.patch` implementing new FFI for injecting custom TLS ClientHello
- adjust `maintain_quiche.sh` to use `libs/patches`

## Testing
- `./scripts/quiche_workflow.sh --step patch`
- `cargo build --workspace` *(fails: missing BoringSSL source)*

------
https://chatgpt.com/codex/tasks/task_e_6869b35f8d0c83339d247db3983163e3