### PR TITLE
Add QUICHE_PATH export in workflow

### DIFF
--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -39,6 +39,9 @@ STATE_FILE="$BASE_DIR/.quiche_workflow_state"
 BUILD_TYPE="release"
 MIRROR_URL="https://github.com/cloudflare/quiche.git"
 
+# Make quiche available to Cargo
+export QUICHE_PATH="$PATCHED_DIR/quiche"
+
 # Erstelle benötigte Verzeichnisse
 mkdir -p "$LOG_DIR" "$PATCHES_DIR" "$PATCHED_DIR"
 


### PR DESCRIPTION
## Summary
- ensure `quiche_workflow.sh` exports `QUICHE_PATH` so Cargo can find the patched quiche source

## Testing
- `cargo test --workspace --quiet` *(fails: "failed to run custom build command for `quiche`" because boringssl source missing)*

------
https://chatgpt.com/codex/tasks/task_e_6869bb0d6fb48333bf429835bcb10ef1