### PR TITLE
Fix quiche path and CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,15 @@ jobs:
         run: |
           ./scripts/quiche_workflow.sh --step fetch
 
+      - name: Ensure QUICHE_PATH
+        shell: bash
+        run: |
+          echo "QUICHE_PATH=${{ github.workspace }}/libs/patched_quiche/quiche" >> $GITHUB_ENV
+          if [ ! -d "${{ github.workspace }}/libs/patched_quiche/quiche" ]; then
+            echo "libs/patched_quiche/quiche missing" >&2
+            exit 1
+          fi
+
       - name: Run Clippy
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 aligned_box = "0.2"
-quiche = { path = "libs/vanilla_quiche/quiche" }
+quiche = { path = "libs/patched_quiche/quiche" }
 rustls = "0.22.2"
 aegis = "0.9.0"
 morus = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ The `libs/patched_quiche` directory is intentionally left empty to keep the
 checkout small. Fetch the sources after cloning by running the workflow
 script below.
 After cloning simply run the workflow script which fetches the sources and
-initializes the submodule automatically:
+initializes the submodule automatically. The script exports `QUICHE_PATH`
+to `libs/patched_quiche/quiche` so that Cargo can find the library:
 
 ```bash
 ./scripts/quiche_workflow.sh --step fetch
@@ -107,6 +108,12 @@ git submodule set-url libs/patched_quiche <mirror-url>
 The workflow script replaces the old `fetch_quiche.sh` helper and can be
 re-run at any time. If a local copy of quiche already exists, set the
 `QUICHE_PATH` environment variable to use that path instead.
+When building manually make sure this variable points to
+`libs/patched_quiche/quiche`:
+
+```bash
+export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche
+```
 
 ### Building quiche
 

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -147,6 +147,15 @@ apply_patches() {
     else
         warn "Keine Patch-Dateien im .patch-Format gefunden"
     fi
+
+    # Stelle sicher, dass das Build-Verzeichnis existiert
+    local build_dir="$PATCHED_DIR/target"
+    if [ -d "$build_dir" ]; then
+        log "Build-Verzeichnis bereits vorhanden: $build_dir"
+    else
+        log "Erstelle Build-Verzeichnis: $build_dir"
+        mkdir -p "$build_dir"
+    fi
 }
 
 # Schritt 3: Quiche bauen

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -36,10 +36,10 @@ async fn client_server_end_to_end() {
     .unwrap();
     let mut server_config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
     server_config
-        .load_cert_chain_from_pem_file("libs/vanilla_quiche/quiche/examples/cert.crt")
+        .load_cert_chain_from_pem_file("libs/patched_quiche/quiche/examples/cert.crt")
         .unwrap();
     server_config
-        .load_priv_key_from_pem_file("libs/vanilla_quiche/quiche/examples/cert.key")
+        .load_priv_key_from_pem_file("libs/patched_quiche/quiche/examples/cert.key")
         .unwrap();
     server_config
         .set_application_protos(b"\x0ahq-interop\x05h3-29\x05h3-28\x05h3-27\x08http/0.9")


### PR DESCRIPTION
## Summary
- point `quiche` dependency to the patched source
- add build directory check in the quiche workflow script
- ensure `QUICHE_PATH` is exported during CI
- adjust test cert paths
- document manual QUICHE_PATH usage

## Testing
- `./scripts/quiche_workflow.sh --step fetch`
- `./scripts/quiche_workflow.sh --step patch` *(fails: Only garbage was found in the patch input)*
- `cargo test --workspace --all-targets` *(fails: CMake Error: The source directory libs/patched_quiche/quiche/deps/boringssl does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_686a673427388333ba8044346eade7c5