### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -72,7 +72,15 @@ jobs:
       run: |
         chmod +x ./scripts/quiche_workflow.sh
         ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
-    
+
+    - name: Build QuicFuscate binaries
+      run: |
+        if [ "${{ inputs.build_type || 'release' }}" = "release" ]; then
+          cargo build --release
+        else
+          cargo build
+        fi
+
     - name: Upload Artifacts
       uses: actions/upload-artifact@v4
       with:
@@ -80,6 +88,7 @@ jobs:
         path: |
           libs/patched_quiche/target/${{ inputs.build_type || 'release' }}/quiche
           libs/patched_quiche/target/${{ inputs.build_type || 'release' }}/deps/*.rlib
+          target/${{ inputs.build_type || 'release' }}/quicfuscate*
         retention-days: 7
         compression-level: 9
     
@@ -91,6 +100,7 @@ jobs:
           libs/patched_quiche/target/${{ inputs.build_type || 'release' }}/quiche
           libs/patched_quiche/target/${{ inputs.build_type || 'release' }}/*.a
           libs/patched_quiche/target/${{ inputs.build_type || 'release' }}/deps/*.rlib
+          target/${{ inputs.build_type || 'release' }}/quicfuscate*
         generate_release_notes: true
         draft: false
         prerelease: false

--- a/README.md
+++ b/README.md
@@ -213,6 +213,14 @@ cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 ```
 
+## 📦 Releases
+
+Pre-built binaries are automatically generated for the `main` and `master`
+branches. Visit the [GitHub Releases](https://github.com/yourname/QuicFuscate/releases)
+page to download the latest `quicfuscate` executables for your platform.
+Each release bundles the patched `quiche` library together with the
+`quicfuscate_*` binaries.
+
 ## 📜 License
 
 This software is provided under a custom license that allows:


### PR DESCRIPTION
## Summary
- include QuicFuscate binaries in build workflow artifacts
- create GitHub releases from `main`/`master` with binaries attached
- document how to obtain binaries

## Testing
- `cargo test --workspace` *(fails: missing `boringssl` for quiche build)*

------
https://chatgpt.com/codex/tasks/task_e_686a673975408333b5f01258fc05722f