### PR TITLE
Improve quiche workflow fetch logic

### DIFF
--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -54,6 +54,12 @@ load_state() {
         LAST_STEP="none"
         BUILD_TYPE="${BUILD_TYPE:-release}"
     fi
+
+    # Ensure quiche sources are present
+    if [ ! -d "$PATCHED_DIR/quiche" ]; then
+        warn "Quiche-Verzeichnis fehlt: $PATCHED_DIR/quiche"
+        fetch_quiche || error "Automatisches Herunterladen fehlgeschlagen. Bitte $0 --step fetch ausf\xC3\xBChren."
+    fi
 }
 
 # Speichere den aktuellen Status
@@ -89,6 +95,11 @@ run_command() {
 # Schritt 1: Quiche herunterladen
 fetch_quiche() {
     local log_file="$LOG_DIR/fetch_quiche_$(date +%Y%m%d_%H%M%S).log"
+
+    if [ -d "$PATCHED_DIR/quiche" ]; then
+        log "Quiche-Verzeichnis bereits vorhanden: $PATCHED_DIR/quiche"
+        return 0
+    fi
     
     log "Starte Herunterladen von quiche..."
     log "Quelle: $MIRROR_URL"
@@ -110,7 +121,11 @@ fetch_quiche() {
         run_command "Klonen des Quiche-Repositories" \
             "git clone --depth 1 \"$MIRROR_URL\" \"$PATCHED_DIR\""
     fi
-    
+
+    if [ ! -d "$PATCHED_DIR/quiche" ]; then
+        error "Quiche-Verzeichnis konnte nach dem Klonen nicht gefunden werden"
+    fi
+
     success "Quiche erfolgreich heruntergeladen und vorbereitet"
     return 0
 }

--- a/tests/quiche_workflow.bats
+++ b/tests/quiche_workflow.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+setup() {
+    tmpdir=$(mktemp -d)
+    repo="$tmpdir/repo"
+    mkdir -p "$repo/quiche"
+    echo "test" > "$repo/quiche/README.md"
+    git init -q "$repo"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "init"
+
+    proj="$tmpdir/project"
+    mkdir -p "$proj/scripts"
+    cp scripts/quiche_workflow.sh "$proj/scripts/"
+    mkdir -p "$proj/libs/patches"
+
+    cd "$proj"
+}
+
+teardown() {
+    rm -rf "$tmpdir"
+}
+
+@test "automatically fetches quiche when missing" {
+    MIRROR_URL="file://$repo" ./scripts/quiche_workflow.sh --step patch
+    [ -d "libs/patched_quiche/quiche" ]
+}
+


### PR DESCRIPTION
## Summary
- auto-fetch quiche sources if missing when loading workflow state
- skip fetch if quiche directory already exists
- error if cloning did not produce `quiche` directory
- add bats unit test for this logic

## Testing
- `bats tests/quiche_workflow.bats`
- `cargo test --quiet` *(fails: `could not compile quiche`)*

------
https://chatgpt.com/codex/tasks/task_e_686a7712138c833397e034e759aa0daf