### PR TITLE
Add verify-peer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Run `quicfuscate_demo --help` to see all available options. Important flags incl
   -p, --port <port>          Server port (default: 443)
   -f, --fingerprint <name>   Browser fingerprint (chrome, firefox, safari, ...)
       --no-utls              Disable uTLS and use regular TLS
-      --verify-peer          Enable certificate validation
+      --verify-peer          Validate the server certificate (disabled by default)
       --ca-file <path>       CA file for peer verification
   -v, --verbose              Verbose logging
       --debug-tls            Show TLS debug information

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ enum Commands {
         #[clap(long, value_enum, default_value = "zero")]
         fec_mode: FecMode,
 
+        /// Enable certificate validation when connecting to the server
+        #[clap(long)]
+        verify_peer: bool,
+
         /// Disable DNS over HTTPS
         #[clap(long)]
         disable_doh: bool,
@@ -157,6 +161,7 @@ async fn main() -> std::io::Result<()> {
                 profile_seq,
                 *profile_interval,
                 *fec_mode,
+                *verify_peer,
                 *disable_doh,
                 *disable_fronting,
                 *disable_xor,
@@ -222,6 +227,7 @@ async fn run_client(
     profile_seq: &Option<Vec<String>>,
     profile_interval: u64,
     fec_mode: FecMode,
+    verify_peer: bool,
     disable_doh: bool,
     disable_fronting: bool,
     disable_xor: bool,
@@ -253,7 +259,7 @@ async fn run_client(
     config.set_initial_max_stream_data_bidi_remote(1_000_000);
     config.set_initial_max_streams_bidi(100);
     config.set_initial_max_streams_uni(100);
-    config.verify_peer(false); // In a real app, you should verify the server cert.
+    config.verify_peer(verify_peer);
 
     let url_parsed =
         url::Url::parse(url).unwrap_or_else(|_| url::Url::parse("https://example.com/").unwrap());


### PR DESCRIPTION
## Summary
- add `--verify-peer` flag for client CLI
- hook up certificate verification when creating client config
- document the new flag in the README

## Testing
- `cargo check` *(fails: unexpected closing delimiter in src/fec/mod.rs)*
- `cargo test` *(fails: unexpected closing delimiter in src/fec/mod.rs)*

------
https://chatgpt.com/codex/tasks/task_e_686a911e06708333b6fa86702c2f09c3