### PR TITLE
Enable custom DoH and domain fronting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ Run `quicfuscate_demo --help` to see all available options. Important flags incl
       --debug-tls            Show TLS debug information
       --list-fingerprints    List available browser fingerprints
       --fec-mode <mode>      Initial FEC mode (zero|light|normal|medium|strong|extreme)
+      --doh-provider <url>   Custom DNS-over-HTTPS resolver
+      --front-domain <d>     Domain used for fronting (repeat or comma separated)
       --disable-doh          Disable DNS over HTTPS
       --disable-fronting     Disable domain fronting
       --disable-xor          Disable XOR obfuscation


### PR DESCRIPTION
## Summary
- add `fronting_domains` field to `StealthConfig`
- support custom domain lists in `DomainFrontingManager`
- expose `--doh-provider` and `--front-domain` CLI arguments
- wire new options through client/server setup
- document the new flags in the README

## Testing
- `cargo test --quiet` *(fails: failed to load source for dependency `quiche`)*

------
https://chatgpt.com/codex/tasks/task_e_686a911e7b648333a6022e3e7d6ba81f