### PR TITLE
Add patch verification step and test

### DIFF
--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -150,6 +150,10 @@ apply_patches() {
         if [ -f "$patch_file" ]; then
             patch_count=$((patch_count + 1))
             log "Wende Patch an: $(basename "$patch_file")"
+
+            if ! (cd "$PATCHED_DIR" && git apply --check "$patch_file" >/dev/null 2>&1); then
+                error "Patch $(basename "$patch_file") kann nicht angewendet werden (git apply --check fehlgeschlagen)"
+            fi
             
             if ! (cd "$PATCHED_DIR" && patch -p1 --no-backup-if-mismatch -r - < "$patch_file"); then
                 error "Fehler beim Anwenden von $(basename "$patch_file")"

--- a/tests/quiche_patch_failure.bats
+++ b/tests/quiche_patch_failure.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+setup() {
+    tmpdir=$(mktemp -d)
+    repo="$tmpdir/repo"
+    mkdir -p "$repo/quiche"
+    echo "test" > "$repo/quiche/README.md"
+    git init -q "$repo"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "init"
+
+    proj="$tmpdir/project"
+    mkdir -p "$proj/scripts"
+    cp scripts/quiche_workflow.sh "$proj/scripts/"
+    mkdir -p "$proj/libs/patches"
+
+    # Create a patch that will not apply
+    cat > "$proj/libs/patches/bad.patch" <<'PATCH'
+--- a/unknown.txt
++++ b/unknown.txt
+@@
++broken
+PATCH
+
+    cd "$proj"
+}
+
+teardown() {
+    rm -rf "$tmpdir"
+}
+
+@test "fails when patches do not apply" {
+    run env MIRROR_URL="file://$repo" ./scripts/quiche_workflow.sh --step patch
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"git apply --check fehlgeschlagen"* ]]
+}
+


### PR DESCRIPTION
## Summary
- validate patches with `git apply --check` before applying
- abort when verification fails with a clear message
- add BATS test covering patch failures

## Testing
- `npx --yes bats tests/quiche_patch_failure.bats`
- `npx --yes bats tests/quiche_workflow.bats`
- `cargo test --quiet` *(fails: failed to read `/workspace/QuicFuscate/libs/patched_quiche/quiche/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686a911eb7b083339eca2d943b5c2f21