### PR TITLE
Add fec-config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,12 +192,21 @@ Run `quicfuscate_demo --help` to see all available options. Important flags incl
       --debug-tls            Show TLS debug information
       --list-fingerprints    List available browser fingerprints
       --fec-mode <mode>      Initial FEC mode (zero|light|normal|medium|strong|extreme)
+      --fec-config <path>    Load Adaptive FEC settings from TOML file
       --doh-provider <url>   Custom DNS-over-HTTPS resolver
       --front-domain <d>     Domain used for fronting (repeat or comma separated)
       --disable-doh          Disable DNS over HTTPS
       --disable-fronting     Disable domain fronting
       --disable-xor          Disable XOR obfuscation
       --disable-http3        Disable HTTP/3 masquerading
+```
+
+Example FEC configuration:
+
+```toml
+[adaptive_fec]
+lambda = 0.05
+burst_window = 30
 ```
 
 ## 🔄 Continuous Integration

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3,13 +3,15 @@
 ## Client
 
 ```
-quicfuscate client --remote 203.0.113.1:4433 --local 127.0.0.1:1080 --profile chrome
+quicfuscate client --remote 203.0.113.1:4433 --local 127.0.0.1:1080 --profile chrome --fec-config ./fec.toml
 ```
 
 ## Server
 
 ```
-quicfuscate server --listen 0.0.0.0:4433 --cert ./server.crt --key ./server.key --profile firefox
+quicfuscate server --listen 0.0.0.0:4433 --cert ./server.crt --key ./server.key --profile firefox --fec-config ./fec.toml
 ```
 
 Ensure certificate and key are valid PEM files. Use `CTRL+C` to gracefully stop the process.
+
+The optional `--fec-config` flag loads Adaptive FEC parameters from the specified TOML file.

--- a/src/core.rs
+++ b/src/core.rs
@@ -86,7 +86,7 @@ impl QuicFuscateConnection {
         remote_addr: SocketAddr,
         mut config: quiche::Config,
         stealth_config: StealthConfig,
-        fec_mode: FecMode,
+        mut fec_config: FecConfig,
     ) -> Result<Self, String> {
         // --- Explicitly set BBRv2 Congestion Control as per PLAN.txt ---
         config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
@@ -119,7 +119,7 @@ impl QuicFuscateConnection {
             stealth_manager,
             optimization_manager,
             xdp_socket,
-            fec_mode,
+            fec_config,
         ))
     }
 
@@ -130,7 +130,7 @@ impl QuicFuscateConnection {
         remote_addr: SocketAddr,
         mut config: quiche::Config,
         stealth_config: StealthConfig,
-        fec_mode: FecMode,
+        mut fec_config: FecConfig,
     ) -> Result<Self, String> {
         config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
         config.enable_mtu_probing();
@@ -156,7 +156,7 @@ impl QuicFuscateConnection {
             stealth_manager,
             optimization_manager,
             xdp_socket,
-            fec_mode,
+            fec_config,
         ))
     }
 
@@ -168,20 +168,9 @@ impl QuicFuscateConnection {
         stealth_manager: Arc<StealthManager>,
         optimization_manager: Arc<OptimizationManager>,
         xdp_socket: Option<XdpSocket>,
-        fec_mode: FecMode,
+        fec_config: FecConfig,
     ) -> Self {
-        let fec_config = FecConfig {
-            lambda: 0.1,
-            burst_window: 20,
-            hysteresis: 0.02,
-            pid: PidConfig {
-                kp: 0.5,
-                ki: 0.1,
-                kd: 0.2,
-            },
-            initial_mode: fec_mode,
-            window_sizes: FecConfig::default_windows(),
-        };
+
 
         Self {
             conn,

--- a/src/fec/adaptive.rs
+++ b/src/fec/adaptive.rs
@@ -308,6 +308,8 @@ impl PidController {
 
         (self.config.kp * error) + (self.config.ki * self.integral) + (self.config.kd * derivative)
     }
+}
+
 pub struct AdaptiveFec {
     estimator: Arc<Mutex<LossEstimator>>,
     mode_mgr: Arc<Mutex<ModeManager>>,

--- a/src/fec/mod.rs
+++ b/src/fec/mod.rs
@@ -79,19 +79,6 @@ impl KalmanFilter {
 }
 
 
-
-            self.transition_decoder = Some(std::mem::replace(
-                &mut self.decoder,
-                DecoderVariant::new(old_mode, ok, Arc::clone(&self.mem_pool)),
-            ));
-            self.transition_left = ModeManager::CROSS_FADE_LEN;
-        } else {
-            self.encoder = EncoderVariant::new(new_mode, k, n);
-            self.decoder = DecoderVariant::new(new_mode, k, Arc::clone(&self.mem_pool));
-        }
-    }
-}
-
 // [Die Tests wurden oben nicht verändert und bleiben wie im Input – ebenfalls konfliktfrei!]
 //
 //     * Neither the name of the copyright holder nor the names of its


### PR DESCRIPTION
## Summary
- add `--fec-config` option to CLI for client and server
- parse FEC parameters from TOML files
- document new option in README and usage docs
- adjust tests for new API and add config file test

## Testing
- `cargo test --workspace --no-run` *(fails: expected outer doc comment, many compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_686aa287cf688333bcc1add6bb59d8cc