### PR TITLE
Add quiche test step

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -68,10 +68,24 @@ jobs:
         chmod +x ./scripts/quiche_workflow.sh
         ./scripts/quiche_workflow.sh --step patch
 
-    - name: build_quiche
-      run: |
-        chmod +x ./scripts/quiche_workflow.sh
-        ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
+      - name: build_quiche
+        run: |
+          chmod +x ./scripts/quiche_workflow.sh
+          ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
+
+      - name: test_quiche
+        run: |
+          chmod +x ./scripts/quiche_workflow.sh
+          ./scripts/quiche_workflow.sh --step test
+
+      - name: Upload Test Logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quiche-test-logs
+          path: libs/logs/
+          retention-days: 7
+          compression-level: 9
 
     - name: Build QuicFuscate binaries
       run: |

--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -177,9 +177,13 @@ QuicFuscate includes a GitHub Actions workflow for automated building and testin
 2. **Build Process**
    - Executes the quiche workflow script
    - Supports both release and debug builds
-  - Applies all patches from `libs/patches/*.patch`
+   - Applies all patches from `libs/patches/*.patch`
 
-3. **Artifact Handling**
+3. **Test Process**
+   - Runs `scripts/quiche_workflow.sh --step test`
+   - Uploads logs from `libs/logs` as workflow artifacts
+
+4. **Artifact Handling**
    - Packages the built artifacts
    - Uploads them as workflow artifacts
    - Creates GitHub releases for stable builds


### PR DESCRIPTION
## Summary
- add a `test_quiche` step to the build workflow
- upload logs from the new test step
- document the test step in the quiche dependency docs

## Testing
- `cargo test --workspace --all-targets --locked` *(fails: failed to load source for dependency `quiche`)*

------
https://chatgpt.com/codex/tasks/task_e_686aa28a4a608333bf285b88aaabb955