### PR TITLE
Add quiche tests to build workflow

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -73,6 +73,19 @@ jobs:
         chmod +x ./scripts/quiche_workflow.sh
         ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
 
+    - name: test_quiche
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step test
+
+    - name: Upload Test Logs
+      uses: actions/upload-artifact@v4
+      with:
+        name: quiche-test-logs
+        path: libs/logs/
+        retention-days: 7
+        compression-level: 9
+
     - name: Build QuicFuscate binaries
       run: |
         if [ "${{ inputs.build_type || 'release' }}" = "release" ]; then

--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -167,6 +167,7 @@ QuicFuscate includes a GitHub Actions workflow for automated building and testin
 - **Manual Triggers**: Supports manual execution with custom build types
 - **Artifact Publishing**: Automatically uploads build artifacts
 - **Release Management**: Creates GitHub releases for main/master builds
+- **Automated Testing**: Executes quiche tests and stores logs as artifacts
 
 #### Workflow Steps
 1. **Setup Environment**
@@ -179,8 +180,12 @@ QuicFuscate includes a GitHub Actions workflow for automated building and testin
    - Supports both release and debug builds
   - Applies all patches from `libs/patches/*.patch`
 
-3. **Artifact Handling**
-   - Packages the built artifacts
+3. **Test Execution**
+   - Runs `scripts/quiche_workflow.sh --step test`
+   - Captures test logs for later inspection
+
+4. **Artifact Handling**
+   - Packages the built artifacts and test logs
    - Uploads them as workflow artifacts
    - Creates GitHub releases for stable builds
 


### PR DESCRIPTION
## Summary
- run `scripts/quiche_workflow.sh --step test` in CI
- upload generated test logs
- document new automated testing step

## Testing
- `cargo test` *(fails: failed to get `quiche` as a dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686aa6ed83f083338183f2ac42977bf9