### PR TITLE
Fix duplicate field in client command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,10 +59,6 @@ enum Commands {
         #[clap(long, value_name = "PATH")]
         fec_config: Option<PathBuf>,
 
-        /// Path to a TOML file with Adaptive FEC settings
-        #[clap(long, value_name = "PATH")]
-        fec_config: Option<PathBuf>,
-
         /// Custom DNS-over-HTTPS provider URL
         #[clap(long, default_value = "https://cloudflare-dns.com/dns-query")]
         doh_provider: String,


### PR DESCRIPTION
## Summary
- remove duplicate `fec_config` definition from `Commands::Client`

## Testing
- `cargo build -q` *(fails: could not compile `quicfuscate`)*
- `cargo test -q` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686aaf7463f083338335b012e603382b