### PR TITLE
Fix step indentation in build workflow

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -68,24 +68,24 @@ jobs:
         chmod +x ./scripts/quiche_workflow.sh
         ./scripts/quiche_workflow.sh --step patch
 
-      - name: build_quiche
-        run: |
-          chmod +x ./scripts/quiche_workflow.sh
-          ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
+    - name: build_quiche
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
 
-      - name: test_quiche
-        run: |
-          chmod +x ./scripts/quiche_workflow.sh
-          ./scripts/quiche_workflow.sh --step test
+    - name: test_quiche
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step test
 
-      - name: Upload Test Logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: quiche-test-logs
-          path: libs/logs/
-          retention-days: 7
-          compression-level: 9
+    - name: Upload Test Logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: quiche-test-logs
+        path: libs/logs/
+        retention-days: 7
+        compression-level: 9
 
     - name: Build QuicFuscate binaries
       run: |


### PR DESCRIPTION
## Summary
- fix indentation for `build_quiche`, `test_quiche`, and `Upload Test Logs` in `build-quiche.yml`
- verified YAML parses correctly

## Testing
- `python - <<'PY'
import yaml, sys
with open('.github/workflows/build-quiche.yml') as f:
    yaml.safe_load(f)
print("YAML syntax ok")
PY`
- `cargo test` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686af910b6cc8333a5332e03eb0a5597