### PR TITLE
Ignore libs log directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ tests/*.o
 # CLion
 .idea/
 cmake-build-*/
+libs/logs/


### PR DESCRIPTION
## Summary
- add `libs/logs/` entry in `.gitignore` to keep log files out of git

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b9c107b9883339b5a3a1b4f1760fb