### PR TITLE
Fix misaligned steps in build workflow

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -68,24 +68,24 @@ jobs:
         chmod +x ./scripts/quiche_workflow.sh
         ./scripts/quiche_workflow.sh --step patch
 
-      - name: build_quiche
-        run: |
-          chmod +x ./scripts/quiche_workflow.sh
-          ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
+    - name: build_quiche
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step build --type ${{ inputs.build_type || 'release' }}
 
-      - name: test_quiche
-        run: |
-          chmod +x ./scripts/quiche_workflow.sh
-          ./scripts/quiche_workflow.sh --step test
+    - name: test_quiche
+      run: |
+        chmod +x ./scripts/quiche_workflow.sh
+        ./scripts/quiche_workflow.sh --step test
 
-      - name: Upload Test Logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: quiche-test-logs
-          path: libs/logs/
-          retention-days: 7
-          compression-level: 9
+    - name: Upload Test Logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: quiche-test-logs
+        path: libs/logs/
+        retention-days: 7
+        compression-level: 9
 
     - name: Build QuicFuscate binaries
       run: |


### PR DESCRIPTION
## Summary
- fix indentation in `build-quiche.yml` so that `build_quiche`, `test_quiche`, and `Upload Test Logs` execute properly

## Testing
- `yamllint .github/workflows/build-quiche.yml` *(fails: line-length, trailing spaces)*
- `python3 - <<'EOF'
import yaml
open('.github/workflows/build-quiche.yml')
yaml.safe_load(open('.github/workflows/build-quiche.yml'))
print('YAML parsed successfully')
EOF`
- `cargo test` *(fails: failed to get `quiche` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c1010e083338e46e3cc41785a84