### PR TITLE
Add adaptive optimization hooks and metrics

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -15,3 +15,15 @@ quicfuscate server --listen 0.0.0.0:4433 --cert ./server.crt --key ./server.key 
 Ensure certificate and key are valid PEM files. Use `CTRL+C` to gracefully stop the process.
 
 The optional `--fec-config` flag loads Adaptive FEC parameters from the specified TOML file.
+
+### Optimization Parameters
+
+Both client and server accept additional flags to tune the memory pool used for
+zero-copy buffers:
+
+```
+    --pool-capacity <num>    Number of blocks to keep in the pool (default: 1024)
+    --pool-block <bytes>     Size of each block in bytes (default: 4096)
+```
+Increase the capacity when handling high traffic volumes or decrease it to save
+memory.

--- a/src/core.rs
+++ b/src/core.rs
@@ -37,7 +37,7 @@
 
 use crate::crypto::{CipherSuiteSelector, CryptoManager};
 use crate::fec::{AdaptiveFec, FecConfig, Packet as FecPacket, PidConfig};
-use crate::optimize::{MemoryPool, OptimizationManager};
+use crate::optimize::{MemoryPool, OptimizationManager, OptimizeConfig};
 use crate::stealth::{StealthConfig, StealthManager};
 use crate::xdp_socket::XdpSocket;
 use std::collections::VecDeque;
@@ -87,6 +87,7 @@ impl QuicFuscateConnection {
         mut config: quiche::Config,
         stealth_config: StealthConfig,
         mut fec_config: FecConfig,
+        opt_cfg: OptimizeConfig,
     ) -> Result<Self, String> {
         // --- Explicitly set BBRv2 Congestion Control as per PLAN.txt ---
         config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
@@ -94,7 +95,7 @@ impl QuicFuscateConnection {
         config.enable_mtu_probing();
 
         let crypto_manager = Arc::new(CryptoManager::new());
-        let optimization_manager = Arc::new(OptimizationManager::new());
+        let optimization_manager = Arc::new(OptimizationManager::from_cfg(opt_cfg));
         let stealth_manager = Arc::new(StealthManager::new(
             stealth_config,
             crypto_manager.clone(),
@@ -131,12 +132,13 @@ impl QuicFuscateConnection {
         mut config: quiche::Config,
         stealth_config: StealthConfig,
         mut fec_config: FecConfig,
+        opt_cfg: OptimizeConfig,
     ) -> Result<Self, String> {
         config.set_cc_algorithm(quiche::CongestionControlAlgorithm::BBRv2);
         config.enable_mtu_probing();
 
         let crypto_manager = Arc::new(CryptoManager::new());
-        let optimization_manager = Arc::new(OptimizationManager::new());
+        let optimization_manager = Arc::new(OptimizationManager::from_cfg(opt_cfg));
         let stealth_manager = Arc::new(StealthManager::new(
             stealth_config,
             crypto_manager.clone(),

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -9,8 +9,20 @@ use lazy_static::lazy_static;
 //! - `fec_overflow_total`: Number of times the FEC memory pool had to allocate
 //!   a new block because the pool was exhausted.
 //! - `dns_errors_total`: Number of DNS resolution errors.
+//! - `bytes_sent_total`: UDP bytes sent via the core.
+//! - `bytes_received_total`: UDP bytes received via the core.
+//! - `mem_pool_capacity`: Current capacity of the memory pool.
+//! - `mem_pool_in_use`: Number of blocks currently checked out from the pool.
+//! - `cpu_feature_mask`: Bitmask of detected CPU features.
 
-use prometheus::{Encoder, IntCounter, IntGauge, TextEncoder, register_int_counter, register_int_gauge};
+use prometheus::{
+    Encoder,
+    IntCounter,
+    IntGauge,
+    TextEncoder,
+    register_int_counter,
+    register_int_gauge,
+};
 
 lazy_static! {
     pub static ref ENCODED_PACKETS: IntCounter =
@@ -25,6 +37,16 @@ lazy_static! {
         register_int_counter!("fec_overflow_total", "FEC memory pool overflows").unwrap();
     pub static ref DNS_ERRORS: IntCounter =
         register_int_counter!("dns_errors_total", "Number of DNS resolution errors").unwrap();
+    pub static ref BYTES_SENT: IntCounter =
+        register_int_counter!("bytes_sent_total", "Total UDP bytes sent").unwrap();
+    pub static ref BYTES_RECEIVED: IntCounter =
+        register_int_counter!("bytes_received_total", "Total UDP bytes received").unwrap();
+    pub static ref MEM_POOL_CAPACITY: IntGauge =
+        register_int_gauge!("mem_pool_capacity", "Memory pool capacity").unwrap();
+    pub static ref MEM_POOL_IN_USE: IntGauge =
+        register_int_gauge!("mem_pool_in_use", "Memory pool blocks in use").unwrap();
+    pub static ref CPU_FEATURE_MASK: IntGauge =
+        register_int_gauge!("cpu_feature_mask", "Detected CPU features bitmask").unwrap();
 }
 
 pub fn serve(addr: &str) {

--- a/src/xdp_socket.rs
+++ b/src/xdp_socket.rs
@@ -1,5 +1,6 @@
 #[cfg(unix)]
 use crate::optimize::ZeroCopyBuffer;
+use crate::telemetry;
 #[cfg(unix)]
 use std::io::{self, Error, ErrorKind};
 #[cfg(unix)]
@@ -34,6 +35,7 @@ impl XdpSocket {
         if ret < 0 {
             Err(Error::last_os_error())
         } else {
+            telemetry::BYTES_SENT.inc_by(ret as u64);
             Ok(ret as usize)
         }
     }
@@ -46,6 +48,7 @@ impl XdpSocket {
         if ret < 0 {
             Err(Error::last_os_error())
         } else {
+            telemetry::BYTES_RECEIVED.inc_by(ret as u64);
             Ok(ret as usize)
         }
     }


### PR DESCRIPTION
## Summary
- extend telemetry metrics for bytes sent/received, memory pool usage and CPU feature detection
- implement dynamic memory pool tracking and capacity adjustment
- expose optimization configuration via CLI (pool capacity/block size)
- integrate metrics into XDP sockets and core network paths
- document memory pool tuning options

## Testing
- `cargo check` *(fails: failed to load source for dependency `quiche`)*
- `cargo test` *(fails: failed to load source for dependency `quiche`)*

------
https://chatgpt.com/codex/tasks/task_e_686bb63185308333a517587f52bbeb99