### PR TITLE
Expand CLI options and usage docs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -3,18 +3,42 @@
 ## Client
 
 ```
-quicfuscate client --remote 203.0.113.1:4433 --local 127.0.0.1:1080 --profile chrome --fec-config ./fec.toml
+quicfuscate client \
+  --remote 203.0.113.1:4433 \
+  --local 127.0.0.1:1080 \
+  --profile chrome \
+  --front-domain cdn.example.com \
+  --verify-peer \
+  --fec-config ./fec.toml
 ```
 
 ## Server
 
 ```
-quicfuscate server --listen 0.0.0.0:4433 --cert ./server.crt --key ./server.key --profile firefox --fec-config ./fec.toml
+quicfuscate server \
+  --listen 0.0.0.0:4433 \
+  --cert ./server.crt \
+  --key ./server.key \
+  --profile firefox \
+  --fec-config ./fec.toml
 ```
 
 Ensure certificate and key are valid PEM files. Use `CTRL+C` to gracefully stop the process.
 
 The optional `--fec-config` flag loads Adaptive FEC parameters from the specified TOML file.
+
+### Stealth Options
+
+```
+    --front-domain <d>     Domain used for fronting (repeatable)
+    --doh-provider <url>   Custom DNS-over-HTTPS resolver
+    --verify-peer          Validate the server certificate
+    --ca-file <path>       CA file for verification
+    --disable-doh          Disable DNS over HTTPS
+    --disable-fronting     Disable domain fronting
+    --disable-xor          Disable XOR obfuscation
+    --disable-http3        Disable HTTP/3 masquerading
+```
 
 ### Optimization Parameters
 
@@ -27,3 +51,16 @@ zero-copy buffers:
 ```
 Increase the capacity when handling high traffic volumes or decrease it to save
 memory.
+
+### Standard Configuration
+
+The following setup provides a good starting point on most systems:
+
+```
+quicfuscate client \
+  --remote 203.0.113.1:4433 \
+  --profile chrome \
+  --front-domain cdn.example.com \
+  --pool-capacity 1024 \
+  --pool-block 4096
+```

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -36,6 +36,7 @@
 //? inspection (DPI) systems. It integrates multiple strategies to create a
 //! layered defense against network surveillance.
 
+use clap::ValueEnum;
 use lazy_static::lazy_static;
 use log::{debug, error, info};
 use reqwest::Client;
@@ -110,7 +111,7 @@ pub async fn resolve_doh(
 // --- 2. Browser/OS Fingerprinting ---
 
 /// Defines the target browser for fingerprint spoofing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
 pub enum BrowserProfile {
     Chrome,
     Firefox,
@@ -139,7 +140,7 @@ impl std::str::FromStr for BrowserProfile {
 }
 
 /// Defines the target operating system for fingerprint spoofing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, ValueEnum)]
 pub enum OsProfile {
     Windows,
     MacOS,


### PR DESCRIPTION
## Summary
- add clap `ValueEnum` to browser/OS profiles and implement stricter parsing
- extend client/server commands with additional arguments (front domain, CA file, etc.)
- support profile rotation via CLI and optional uTLS usage
- improve FEC config error reporting
- document new flags and example configuration in `USAGE.md`

## Testing
- `cargo fmt`
- `cargo test --no-default-features -- --test-threads=1` *(fails: CMake Error during quiche build)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1a91e648333b183e3be069bdcca