### PR TITLE
Add build.rs check and document fetch step

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -30,6 +30,9 @@ jobs:
       with:
         submodules: 'recursive'
         fetch-depth: 0
+
+    - name: Init submodules
+      run: git submodule update --init --recursive
     
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Init submodules
+        run: git submodule update --init --recursive
+
       - name: Verify submodules
         shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "quicfuscate"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 aligned_box = "0.2"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ When building manually make sure this variable points to
 export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche
 ```
 
+### ⚠️ Ohne Fetch kein Build
+
+`cargo build` schlägt fehl, wenn das Verzeichnis `libs/patched_quiche/quiche`
+noch nicht existiert. Führe deshalb vor dem Bauen immer zuerst:
+
+```bash
+./scripts/quiche_workflow.sh --step fetch
+```
+
 ### Building quiche
 
 Compile the patched **quiche** library using Cargo:

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let quiche_path =
+        env::var("QUICHE_PATH").unwrap_or_else(|_| "libs/patched_quiche/quiche".into());
+    if !Path::new(&quiche_path).exists() {
+        println!("cargo:warning=Quiche sources missing at {}. Run ./scripts/quiche_workflow.sh --step fetch", quiche_path);
+    }
+}


### PR DESCRIPTION
## Summary
- warn in build script if patched quiche sources are missing
- mention that `cargo build` fails without running `quiche_workflow.sh --step fetch`
- set build script in `Cargo.toml`
- ensure CI and build workflow init submodules before running

## Testing
- `cargo fmt`
- `cargo test` *(fails: could not compile `aegis`)*

------
https://chatgpt.com/codex/tasks/task_e_686bcc40a5ac833392dcecc8f932f313