### PR TITLE
Finalize AEAD selection

### DIFF
--- a/tests/crypto_tests.rs
+++ b/tests/crypto_tests.rs
@@ -4,7 +4,8 @@ use quicfuscate::crypto::{CipherSuite, CipherSuiteSelector};
 fn run_test(suite: CipherSuite) {
     let selector = CipherSuiteSelector::with_suite(suite);
     let (key_len, nonce_len) = match suite {
-        CipherSuite::Aegis128X => (32, 32),
+        // Both AEGIS variants operate on 128-bit keys and nonces.
+        CipherSuite::Aegis128X => (16, 16),
         CipherSuite::Aegis128L => (16, 16),
         CipherSuite::Morus1280_128 => (16, 16),
     };


### PR DESCRIPTION
## Summary
- update AEAD selector to use MORUS TLS id 0x1304
- correct AEGIS key sizes in crypto tests

## Testing
- `cargo test --no-run` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686bd085cbb48333aed5e7a4b0d28123