### PR TITLE
Add CLI options and usage updates

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -38,6 +38,9 @@ The optional `--fec-config` flag loads Adaptive FEC parameters from the specifie
     --disable-fronting     Disable domain fronting
     --disable-xor          Disable XOR obfuscation
     --disable-http3        Disable HTTP/3 masquerading
+    --no-utls              Use native TLS instead of uTLS
+    --debug-tls            Dump TLS keys for debugging
+    --list-fingerprints    Show available browser fingerprints
 ```
 
 ### Optimization Parameters
@@ -61,6 +64,16 @@ quicfuscate client \
   --remote 203.0.113.1:4433 \
   --profile chrome \
   --front-domain cdn.example.com \
+  --pool-capacity 1024 \
+  --pool-block 4096
+```
+
+```
+quicfuscate server \
+  --listen 0.0.0.0:4433 \
+  --cert ./server.crt \
+  --key ./server.key \
+  --profile chrome \
   --pool-capacity 1024 \
   --pool-block 4096
 ```


### PR DESCRIPTION
## Summary
- expose FEC and memory pool options for the server CLI
- show errors when no valid `--profile-seq` entries are supplied
- document advanced stealth flags
- expand example standard configuration for both client and server

## Testing
- `cargo check` *(fails: unresolved imports)*
- `cargo test --no-run` *(fails: unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_686bd085f26c8333883a09d33e7d4a1e