### PR TITLE
Improve quiche workflow docs

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -48,6 +48,7 @@ jobs:
           build-essential \
           pkg-config \
           libssl-dev \
+          patch
           git
     
     - name: Cache Cargo dependencies

--- a/docs/Workflow_Patches.md
+++ b/docs/Workflow_Patches.md
@@ -37,3 +37,21 @@ git -C patched_quiche reset --hard HEAD~1
 ```
 
 Store the patch under `libs/patches/`. The workflow applies all patches automatically during builds.
+
+## GitHub Actions
+
+The repository provides an automated workflow in `.github/workflows/build-quiche.yml`.
+It clones the project with all submodules, runs the helper script for each step
+(fetch, patch, verify, build and test) and uploads the resulting artifacts. Run
+it manually from the GitHub UI or trigger it on each push.
+
+### When to create new patches
+
+Create a new patch whenever:
+
+- the quiche submodule is updated,
+- custom TLS handling or SIMD optimizations change, or
+- additional features require modifications to the vendored quiche sources.
+
+Use the procedure above to generate a `.patch` file and store it under
+`libs/patches/`.

--- a/src/tls_ffi.rs
+++ b/src/tls_ffi.rs
@@ -14,3 +14,8 @@ pub unsafe extern "C" fn quiche_config_set_custom_tls(
 ) {
     log::debug!("quiche_config_set_custom_tls stub invoked");
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn quiche_config_enable_simd(_cfg: *mut c_void) {
+    log::debug!("quiche_config_enable_simd stub invoked");
+}


### PR DESCRIPTION
## Summary
- add stub for `quiche_config_enable_simd`
- document CI workflow and when to create new patches
- install `patch` tool in build workflow

## Testing
- `shellcheck scripts/quiche_workflow.sh scripts/maintain_quiche.sh`
- `cargo check` *(fails: could not compile `quicfuscate` due to 171 previous errors)*

------
https://chatgpt.com/codex/tasks/task_e_686bd08701148333b52b5a7a8f39d003