### PR TITLE
Implement path migration telemetry

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -77,3 +77,13 @@ quicfuscate server \
   --pool-capacity 1024 \
   --pool-block 4096
 ```
+
+### Connection Migration
+
+To migrate an established connection to a new local port, call `migrate_connection` on the active session:
+
+```rust
+let new_addr = "127.0.0.1:0".parse().unwrap();
+conn.migrate_connection(new_addr).unwrap();
+```
+The library records successful migrations via the `path_migrations_total` telemetry counter.

--- a/src/core.rs
+++ b/src/core.rs
@@ -40,6 +40,7 @@ use crate::fec::{AdaptiveFec, FecConfig, Packet as FecPacket, PidConfig};
 use crate::optimize::{MemoryPool, OptimizationManager, OptimizeConfig};
 use crate::stealth::{StealthConfig, StealthManager};
 use crate::xdp_socket::XdpSocket;
+use crate::telemetry;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -444,6 +445,7 @@ impl QuicFuscateConnection {
                     if let Some(ref xdp) = self.xdp_socket {
                         let _ = xdp.update_remote(peer);
                     }
+                    telemetry::PATH_MIGRATIONS.inc();
                 }
                 quiche::PathEvent::FailedValidation(local, peer) => {
                     eprintln!("Path validation failed: {local}->{peer}");
@@ -460,6 +462,7 @@ impl QuicFuscateConnection {
                     if let Some(ref xdp) = self.xdp_socket {
                         let _ = xdp.update_remote(peer);
                     }
+                    telemetry::PATH_MIGRATIONS.inc();
                 }
             }
         }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -13,6 +13,7 @@
 //! - `mem_pool_capacity`: Current capacity of the memory pool.
 //! - `mem_pool_in_use`: Number of blocks currently checked out from the pool.
 //! - `cpu_feature_mask`: Bitmask of detected CPU features.
+//! - `path_migrations_total`: Successful connection migrations.
 
 use prometheus::{
     Encoder,
@@ -70,6 +71,8 @@ lazy_static! {
         register_int_counter!("simd_usage_neon_total", "SIMD NEON dispatches").unwrap();
     pub static ref SIMD_USAGE_SCALAR: IntCounter =
         register_int_counter!("simd_usage_scalar_total", "Scalar dispatches").unwrap();
+    pub static ref PATH_MIGRATIONS: IntCounter =
+        register_int_counter!("path_migrations_total", "Successful connection migrations").unwrap();
 }
 
 pub fn update_memory_usage() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -392,4 +392,5 @@ async fn connection_migration_events() {
     while let Some(_e) = client_conn.conn.path_event_next() {
         // just consume for test
     }
+    assert!(telemetry::PATH_MIGRATIONS.get() > 0);
 }


### PR DESCRIPTION
## Summary
- add `path_migrations_total` metric
- track migrations in `update_state`
- document migration counter
- show migration example in usage docs
- test migration counter

## Testing
- `cargo test` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686be80caec48333a2cabde2c3b46ea6