### PR TITLE
Implement custom TLS workflow

### DIFF
--- a/libs/patches/boringssl_custom_hello.patch
+++ b/libs/patches/boringssl_custom_hello.patch
@@ -1,11 +1,19 @@
 --- a/deps/boringssl/include/openssl/ssl.h
 +++ b/deps/boringssl/include/openssl/ssl.h
 @@
- void SSL_set_custom_client_hello(SSL *ssl, const uint8_t *data, size_t len);
+-void SSL_set_custom_client_hello(SSL *ssl, const uint8_t *data, size_t len);
++// Sets a raw ClientHello buffer that will be sent verbatim.
++void SSL_set_custom_client_hello(SSL *ssl, const uint8_t *data, size_t len);
+--- a/deps/boringssl/ssl/internal.h
++++ b/deps/boringssl/ssl/internal.h
+@@
+ struct ssl_st {
+@@
++  std::vector<uint8_t> custom_client_hello;
+ };
 --- a/deps/boringssl/ssl/ssl_lib.cc
 +++ b/deps/boringssl/ssl/ssl_lib.cc
 @@
  void SSL_set_custom_client_hello(SSL *ssl, const uint8_t *data, size_t len) {
      ssl->custom_client_hello.assign(data, data + len);
  }
-

--- a/libs/patches/custom_tls.patch
+++ b/libs/patches/custom_tls.patch
@@ -118,6 +118,9 @@
      }
  
 +    pub fn set_custom_tls(&mut self, hello: Vec<u8>) {
++        unsafe {
++            SSL_set_custom_client_hello(self.as_mut_ptr(), hello.as_ptr(), hello.len());
++        }
 +        self.custom_tls = Some(hello);
 +    }
      pub fn cipher(&self) -> Option<crypto::Algorithm> {

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -36,6 +36,7 @@
 //? inspection (DPI) systems. It integrates multiple strategies to create a
 //! layered defense against network surveillance.
 
+use base64;
 use clap::ValueEnum;
 use lazy_static::lazy_static;
 use log::{debug, error, info};
@@ -48,7 +49,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 use url::Url;
-use base64;
 
 use crate::crypto::CryptoManager; // Assumed for integration
 use crate::optimize::{self, OptimizationManager}; // Assumed for integration
@@ -721,7 +721,8 @@ impl TlsClientHelloSpoofer {
             out
         }
 
-        let hello = Self::load_client_hello(browser, os).unwrap_or_else(|| build_client_hello(suites));
+        let hello =
+            Self::load_client_hello(browser, os).unwrap_or_else(|| build_client_hello(suites));
         unsafe {
             extern "C" {
                 fn quiche_config_set_custom_tls(cfg: *mut c_void, hello: *const u8, len: usize);
@@ -798,15 +799,33 @@ impl StealthConfig {
         let root: Root = toml::from_str(s)?;
         let mut cfg = StealthConfig::default();
         if let Some(sec) = root.stealth {
-            if let Some(v) = sec.browser_profile { cfg.browser_profile = v; }
-            if let Some(v) = sec.os_profile { cfg.os_profile = v; }
-            if let Some(v) = sec.enable_doh { cfg.enable_doh = v; }
-            if let Some(v) = sec.doh_provider { cfg.doh_provider = v; }
-            if let Some(v) = sec.enable_http3_masquerading { cfg.enable_http3_masquerading = v; }
-            if let Some(v) = sec.use_qpack_headers { cfg.use_qpack_headers = v; }
-            if let Some(v) = sec.enable_domain_fronting { cfg.enable_domain_fronting = v; }
-            if let Some(v) = sec.fronting_domains { cfg.fronting_domains = v; }
-            if let Some(v) = sec.enable_xor_obfuscation { cfg.enable_xor_obfuscation = v; }
+            if let Some(v) = sec.browser_profile {
+                cfg.browser_profile = v;
+            }
+            if let Some(v) = sec.os_profile {
+                cfg.os_profile = v;
+            }
+            if let Some(v) = sec.enable_doh {
+                cfg.enable_doh = v;
+            }
+            if let Some(v) = sec.doh_provider {
+                cfg.doh_provider = v;
+            }
+            if let Some(v) = sec.enable_http3_masquerading {
+                cfg.enable_http3_masquerading = v;
+            }
+            if let Some(v) = sec.use_qpack_headers {
+                cfg.use_qpack_headers = v;
+            }
+            if let Some(v) = sec.enable_domain_fronting {
+                cfg.enable_domain_fronting = v;
+            }
+            if let Some(v) = sec.fronting_domains {
+                cfg.fronting_domains = v;
+            }
+            if let Some(v) = sec.enable_xor_obfuscation {
+                cfg.enable_xor_obfuscation = v;
+            }
         }
         Ok(cfg)
     }
@@ -898,12 +917,7 @@ impl StealthManager {
                 error!("Failed to set custom cipher suites: {}", e);
             }
             // Manipulate TLS ClientHello to match the desired ordering.
-            TlsClientHelloSpoofer::apply(
-                config,
-                fingerprint.browser,
-                fingerprint.os,
-                &suite_ids,
-            );
+            TlsClientHelloSpoofer::apply(config, fingerprint.browser, fingerprint.os, &suite_ids);
         }
 
         config


### PR DESCRIPTION
## Summary
- support raw ClientHello patch in BoringSSL
- use BoringSSL API from quiche when setting custom TLS
- apply patches in defined order
- load .chlo fingerprint in tests

## Testing
- `cargo fmt --all`
- `cargo test --all --quiet` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686beb5d9bbc8333866a436daa22afb4