### PR TITLE
Improve migration and telemetry

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -327,9 +327,10 @@ impl QuicFuscateConnection {
         // Initiate path migration using quiche's API. The local address remains
         // unchanged, but a new peer address is supplied. quiche handles sending
         // the probing packets required for validation.
-        if let Some(ref xdp) = self.xdp_socket {
-            let _ = xdp.update_remote(new_peer);
-        }
+        self.xdp_socket = self
+            .optimization_manager
+            .create_xdp_socket(self.local_addr, new_peer);
+        telemetry::PATH_MIGRATIONS.inc();
         self.conn.migrate(self.local_addr, new_peer)
     }
 
@@ -359,7 +360,7 @@ impl QuicFuscateConnection {
     }
 
     /// Sends a masqueraded HTTP/3 GET request using the stealth manager.
-    pub fn send_http3_request(&mut self, path: &str) -> Result<(), quiche::h3::Error> {
+    pub fn send_http3_request(&mut self, path: &str) -> Result<(), crate::error::ConnectionError> {
         self.init_http3()?;
         let host = self.host_header.clone();
         let headers = self
@@ -383,7 +384,7 @@ impl QuicFuscateConnection {
     }
 
     /// Polls HTTP/3 events and prints received data.
-    pub fn poll_http3(&mut self) -> Result<(), quiche::h3::Error> {
+    pub fn poll_http3(&mut self) -> Result<(), crate::error::ConnectionError> {
         if let Some(ref mut h3) = self.h3_conn {
             let start = std::time::Instant::now();
             loop {
@@ -407,7 +408,7 @@ impl QuicFuscateConnection {
                     }
                     Ok((_id, quiche::h3::Event::Finished)) => {}
                     Err(quiche::h3::Error::Done) => break,
-                    Err(e) => return Err(e),
+                    Err(e) => return Err(e.into()),
                 }
             }
             println!(
@@ -442,9 +443,9 @@ impl QuicFuscateConnection {
                 quiche::PathEvent::Validated(local, peer) => {
                     println!("Path validated: {local}->{peer}");
                     self.peer_addr = peer;
-                    if let Some(ref xdp) = self.xdp_socket {
-                        let _ = xdp.update_remote(peer);
-                    }
+                    self.xdp_socket = self
+                        .optimization_manager
+                        .create_xdp_socket(self.local_addr, peer);
                     telemetry::PATH_MIGRATIONS.inc();
                 }
                 quiche::PathEvent::FailedValidation(local, peer) => {
@@ -459,9 +460,9 @@ impl QuicFuscateConnection {
                 quiche::PathEvent::PeerMigrated(local, peer) => {
                     println!("Peer migrated: {local}->{peer}");
                     self.peer_addr = peer;
-                    if let Some(ref xdp) = self.xdp_socket {
-                        let _ = xdp.update_remote(peer);
-                    }
+                    self.xdp_socket = self
+                        .optimization_manager
+                        .create_xdp_socket(self.local_addr, peer);
                     telemetry::PATH_MIGRATIONS.inc();
                 }
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,8 @@ use thiserror::Error;
 pub enum ConnectionError {
     #[error("quiche error: {0}")]
     Quiche(#[from] quiche::Error),
+    #[error("http3 error: {0}")]
+    H3(#[from] quiche::h3::Error),
     #[error("fec error: {0}")]
     Fec(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -580,6 +580,11 @@ async fn run_client(
         }
 
                 conn.update_state();
+                info!(
+                    "client stats: RTT {:.0} ms, Loss {:.2}%",
+                    conn.stats.rtt,
+                    conn.stats.loss_rate * 100.0
+                );
                 conn.conn.on_timeout();
 
                 // Sleep to avoid busy-looping
@@ -788,6 +793,12 @@ async fn run_server(
                 }
             }
             conn.update_state();
+            info!(
+                "client {} stats: RTT {:.0} ms, Loss {:.2}%",
+                addr,
+                conn.stats.rtt,
+                conn.stats.loss_rate * 100.0
+            );
             conn.conn.on_timeout();
         }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -394,3 +394,106 @@ async fn connection_migration_events() {
     }
     assert!(telemetry::PATH_MIGRATIONS.get() > 0);
 }
+
+#[tokio::test]
+async fn real_quiche_end_to_end() {
+    telemetry::serve("127.0.0.1:0");
+
+    let server_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    server_socket.set_nonblocking(true).unwrap();
+    let server_addr = server_socket.local_addr().unwrap();
+
+    let client_socket = UdpSocket::bind("127.0.0.1:0").unwrap();
+    client_socket.set_nonblocking(true).unwrap();
+    client_socket.connect(server_addr).unwrap();
+
+    let mut client_config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    client_config.verify_peer(false);
+
+    let mut fec_cfg = FecConfig {
+        initial_mode: FecMode::Light,
+        ..FecConfig::default()
+    };
+
+    let mut client_conn = QuicFuscateConnection::new_client(
+        "example.com",
+        client_socket.local_addr().unwrap(),
+        server_addr,
+        client_config,
+        StealthConfig::default(),
+        fec_cfg,
+        OptimizeConfig::default(),
+        true,
+    )
+    .unwrap();
+
+    let mut server_config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+    server_config
+        .load_cert_chain_from_pem_file("libs/vanilla_quiche/quiche/examples/cert.crt")
+        .unwrap();
+    server_config
+        .load_priv_key_from_pem_file("libs/vanilla_quiche/quiche/examples/cert.key")
+        .unwrap();
+    server_config.verify_peer(false);
+
+    let scid = quiche::ConnectionId::from_ref(&[0; quiche::MAX_CONN_ID_LEN]);
+    let client_addr = client_socket.local_addr().unwrap();
+    let mut server_conn = QuicFuscateConnection::new_server(
+        &scid,
+        None,
+        server_addr,
+        client_addr,
+        server_config,
+        StealthConfig::default(),
+        FecConfig::default(),
+        OptimizeConfig::default(),
+    )
+    .unwrap();
+
+    let mut buf = [0u8; 65535];
+    let mut out = [0u8; 65535];
+    let mut request_sent = false;
+    for _ in 0..200 {
+        if let Ok(len) = client_conn.send(&mut out) {
+            if len > 0 {
+                client_socket.send(&out[..len]).unwrap();
+            }
+        }
+        loop {
+            match server_socket.recv_from(&mut buf) {
+                Ok((len, _)) => {
+                    let _ = server_conn.recv(&mut buf[..len]);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(e) => panic!("recv_from server: {}", e),
+            }
+        }
+        if client_conn.conn.is_established() && !request_sent {
+            client_conn.send_http3_request("/").unwrap();
+            request_sent = true;
+        }
+        server_conn.poll_http3().ok();
+        if let Ok(len) = server_conn.send(&mut out) {
+            if len > 0 {
+                server_socket.send_to(&out[..len], client_addr).unwrap();
+            }
+        }
+        loop {
+            match client_socket.recv(&mut buf) {
+                Ok(len) => {
+                    let _ = client_conn.recv(&mut buf[..len]);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => break,
+                Err(e) => panic!("recv client: {}", e),
+            }
+        }
+        client_conn.update_state();
+        server_conn.update_state();
+        if client_conn.conn.is_established() && server_conn.conn.is_established() && request_sent {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    assert!(telemetry::ENCODED_PACKETS.get() > 0);
+}


### PR DESCRIPTION
## Summary
- reinitialize XDP socket on migration events
- convert HTTP/3 helpers to use `ConnectionError`
- log connection stats when verbose
- add end-to-end test using vanilla quiche

## Testing
- `QUICHE_PATH=libs/vanilla_quiche/quiche cargo test --no-run` *(fails: patching boringssl)*

------
https://chatgpt.com/codex/tasks/task_e_686bf7bd6db88333a851cc5d5d72a8a7