### PR TITLE
Implement NUMA-aware memory pool and zero-copy updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ base64 = "0.21"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Networking_WinSock"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# direct FFI to libnuma, no crate dependency
+
 afxdp = { version = "0.4", optional = true }
 
 [features]

--- a/benches/memory_pool.rs
+++ b/benches/memory_pool.rs
@@ -1,0 +1,15 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use quicfuscate::optimize::MemoryPool;
+
+fn bench_pool_alloc(c: &mut Criterion) {
+    let pool = MemoryPool::new(1024, 1024);
+    c.bench_function("memory_pool alloc/free", |b| {
+        b.iter(|| {
+            let block = pool.alloc();
+            pool.free(block);
+        });
+    });
+}
+
+criterion_group!(benches, bench_pool_alloc);
+criterion_main!(benches);

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -54,6 +54,51 @@ use std::os::unix::io::RawFd;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Once};
 
+#[cfg(target_os = "linux")]
+mod numa {
+    use libc::{c_int, c_void, size_t};
+    extern "C" {
+        pub fn numa_available() -> c_int;
+        pub fn numa_num_configured_nodes() -> c_int;
+        pub fn numa_node_of_cpu(cpu: c_int) -> c_int;
+        pub fn numa_tonode_memory(start: *mut c_void, size: size_t, node: c_int);
+    }
+    pub fn is_available() -> bool {
+        unsafe { numa_available() >= 0 }
+    }
+    pub fn num_nodes() -> usize {
+        if is_available() {
+            unsafe { numa_num_configured_nodes() as usize }
+        } else {
+            1
+        }
+    }
+    pub fn current_node() -> usize {
+        if !is_available() {
+            return 0;
+        }
+        let cpu = unsafe { libc::sched_getcpu() };
+        if cpu < 0 {
+            0
+        } else {
+            unsafe { numa_node_of_cpu(cpu) as usize }
+        }
+    }
+    pub unsafe fn move_to_node(ptr: *mut u8, size: usize, node: usize) {
+        if is_available() {
+            numa_tonode_memory(ptr as *mut c_void, size as size_t, node as c_int);
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod numa {
+    pub fn is_available() -> bool { false }
+    pub fn num_nodes() -> usize { 1 }
+    pub fn current_node() -> usize { 0 }
+    pub unsafe fn move_to_node(_ptr: *mut u8, _size: usize, _node: usize) {}
+}
+
 // Use cpufeatures for portable runtime detection
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 
@@ -69,7 +114,7 @@ cpufeatures::new!(
     "pclmulqdq"
 );
 #[cfg(target_arch = "aarch64")]
-cpufeatures::new!(cpuid_arm, "neon");
+cpufeatures::new!(cpuid_arm, "neon", "aes", "pmull");
 
 /// Configuration for optimization parameters passed from the CLI.
 #[derive(Clone, Copy)]
@@ -146,6 +191,8 @@ impl FeatureDetector {
             {
                 let info = cpuid_arm::get();
                 features.insert(CpuFeature::NEON, info.has_neon());
+                features.insert(CpuFeature::AESNI, info.has_aes());
+                features.insert(CpuFeature::PCLMULQDQ, info.has_pmull());
             }
 
             // Unsafe block is required to initialize the static mutable variable.
@@ -287,8 +334,9 @@ where
 /// This implementation uses a concurrent queue to manage free blocks,
 /// minimizing lock contention and fragmentation.
 pub struct MemoryPool {
-    pool: Arc<SegQueue<AlignedBox<[u8]>>>,
+    pools: Vec<Arc<SegQueue<AlignedBox<[u8]>>>>,
     block_size: usize,
+    num_nodes: usize,
     capacity: AtomicUsize,
     in_use: AtomicUsize,
     available: AtomicUsize,
@@ -298,17 +346,33 @@ impl MemoryPool {
     /// Creates a new memory pool with a specified capacity and block size.
     /// All allocated blocks are 64-byte aligned.
     pub fn new(capacity: usize, block_size: usize) -> Self {
-        let queue = Arc::new(SegQueue::new());
-        for _ in 0..capacity {
-            queue.push(AlignedBox::slice_from_default(64, block_size).unwrap());
+        let nodes = numa::num_nodes();
+        let mut pools = Vec::with_capacity(nodes);
+        let mut remaining = capacity;
+        for n in 0..nodes {
+            let node_cap = capacity / nodes + if n < capacity % nodes { 1 } else { 0 };
+            let q = Arc::new(SegQueue::new());
+            for _ in 0..node_cap {
+                let mut block = AlignedBox::slice_from_default(64, block_size).unwrap();
+                #[cfg(target_os = "linux")]
+                unsafe {
+                    if numa::is_available() {
+                        numa::move_to_node(block.as_mut_ptr(), block_size, n);
+                    }
+                }
+                q.push(block);
+            }
+            pools.push(q);
+            remaining -= node_cap;
         }
         telemetry::MEM_POOL_CAPACITY.set(capacity as i64);
         telemetry::MEM_POOL_USAGE_BYTES.set(0);
         telemetry::MEM_POOL_FRAGMENTATION.set(0);
         telemetry::MEM_POOL_UTILIZATION.set(0);
         let pool = Self {
-            pool: queue,
+            pools,
             block_size,
+            num_nodes: nodes,
             capacity: AtomicUsize::new(capacity),
             in_use: AtomicUsize::new(0),
             available: AtomicUsize::new(capacity),
@@ -319,10 +383,21 @@ impl MemoryPool {
 
     fn grow(&self, new_capacity: usize) {
         while self.capacity.load(Ordering::Relaxed) < new_capacity {
-            self.pool
-                .push(AlignedBox::slice_from_default(64, self.block_size).unwrap());
-            self.available.fetch_add(1, Ordering::Relaxed);
-            self.capacity.fetch_add(1, Ordering::Relaxed);
+            for (n, q) in self.pools.iter().enumerate() {
+                if self.capacity.load(Ordering::Relaxed) >= new_capacity {
+                    break;
+                }
+                let mut block = AlignedBox::slice_from_default(64, self.block_size).unwrap();
+                #[cfg(target_os = "linux")]
+                unsafe {
+                    if numa::is_available() {
+                        numa::move_to_node(block.as_mut_ptr(), self.block_size, n);
+                    }
+                }
+                q.push(block);
+                self.available.fetch_add(1, Ordering::Relaxed);
+                self.capacity.fetch_add(1, Ordering::Relaxed);
+            }
         }
         telemetry::MEM_POOL_CAPACITY.set(self.capacity.load(Ordering::Relaxed) as i64);
         self.update_metrics();
@@ -343,12 +418,15 @@ impl MemoryPool {
     /// Allocates a 64-byte aligned memory block from the pool.
     /// If the pool is empty, a new block is created.
     pub fn alloc(&self) -> AlignedBox<[u8]> {
-        if let Some(b) = self.pool.pop() {
-            self.available.fetch_sub(1, Ordering::Relaxed);
-            let cnt = self.in_use.fetch_add(1, Ordering::Relaxed) + 1;
-            self.update_metrics();
-            telemetry::update_memory_usage();
-            return b;
+        let node = numa::current_node();
+        if let Some(queue) = self.pools.get(node) {
+            if let Some(mut b) = queue.pop() {
+                self.available.fetch_sub(1, Ordering::Relaxed);
+                self.in_use.fetch_add(1, Ordering::Relaxed);
+                self.update_metrics();
+                telemetry::update_memory_usage();
+                return b;
+            }
         }
         telemetry::FEC_OVERFLOWS.inc();
         let new_cap = self.capacity.load(Ordering::Relaxed) * 2;
@@ -356,15 +434,25 @@ impl MemoryPool {
         self.in_use.fetch_add(1, Ordering::Relaxed);
         self.update_metrics();
         telemetry::update_memory_usage();
-        AlignedBox::slice_from_default(64, self.block_size).unwrap()
+        let mut block = AlignedBox::slice_from_default(64, self.block_size).unwrap();
+        #[cfg(target_os = "linux")]
+        unsafe {
+            if numa::is_available() {
+                numa::move_to_node(block.as_mut_ptr(), self.block_size, node);
+            }
+        }
+        block
     }
 
     /// Returns a memory block to the pool.
     /// If the pool is full, the block is dropped.
     pub fn free(&self, mut block: AlignedBox<[u8]>) {
         block.iter_mut().for_each(|x| *x = 0);
+        let node = numa::current_node();
         if self.available.load(Ordering::Relaxed) < self.capacity.load(Ordering::Relaxed) {
-            self.pool.push(block);
+            if let Some(q) = self.pools.get(node) {
+                q.push(block);
+            }
             self.available.fetch_add(1, Ordering::Relaxed);
         }
         self.in_use.fetch_sub(1, Ordering::Relaxed);
@@ -381,13 +469,15 @@ impl MemoryPool {
             // shrink: drop excess blocks
             let mut diff = current - new_capacity;
             while diff > 0 && self.available.load(Ordering::Relaxed) > 0 {
-                if self.pool.pop().is_some() {
-                    self.available.fetch_sub(1, Ordering::Relaxed);
-                    self.capacity.fetch_sub(1, Ordering::Relaxed);
-                    diff -= 1;
-                } else {
-                    break;
+                for q in &self.pools {
+                    if diff == 0 { break; }
+                    if let Some(_) = q.pop() {
+                        self.available.fetch_sub(1, Ordering::Relaxed);
+                        self.capacity.fetch_sub(1, Ordering::Relaxed);
+                        diff -= 1;
+                    }
                 }
+                if diff == 0 { break; }
             }
         }
         telemetry::MEM_POOL_CAPACITY.set(self.capacity.load(Ordering::Relaxed) as i64);
@@ -572,6 +662,26 @@ impl<'a> ZeroCopyBuffer<'a> {
         sent as i32
     }
 
+    pub fn send_to(
+        &self,
+        sock: windows_sys::Win32::Networking::WinSock::SOCKET,
+        addr: SocketAddr,
+    ) -> i32 {
+        use socket2::SockAddr;
+        let sockaddr = SockAddr::from(addr);
+        let mut msg = WSAMSG {
+            name: sockaddr.as_ptr() as *mut _,
+            namelen: sockaddr.len(),
+            lpBuffers: self.bufs.as_ptr() as *mut _,
+            dwBufferCount: self.bufs.len() as u32,
+            Control: WSABUF { len: 0, buf: core::ptr::null_mut() },
+            dwFlags: 0,
+        };
+        let mut sent: u32 = 0;
+        unsafe { WSASendMsg(sock, &msg, 0, &mut sent, core::ptr::null_mut(), None) };
+        sent as i32
+    }
+
     pub fn recv(&mut self, sock: windows_sys::Win32::Networking::WinSock::SOCKET) -> i32 {
         let mut msg = WSAMSG {
             name: core::ptr::null_mut(),
@@ -584,6 +694,38 @@ impl<'a> ZeroCopyBuffer<'a> {
         let mut recvd: u32 = 0;
         unsafe { WSARecvMsg(sock, &mut msg, &mut recvd, core::ptr::null_mut(), None) };
         recvd as i32
+    }
+
+    pub fn recv_from(
+        &mut self,
+        sock: windows_sys::Win32::Networking::WinSock::SOCKET,
+    ) -> io::Result<(i32, SocketAddr)> {
+        use socket2::SockAddr;
+        use windows_sys::Win32::Networking::WinSock::SOCKADDR_STORAGE;
+        let mut storage: SOCKADDR_STORAGE = unsafe { core::mem::zeroed() };
+        let mut msg = WSAMSG {
+            name: &mut storage as *mut _ as *mut _,
+            namelen: core::mem::size_of::<SOCKADDR_STORAGE>() as u32,
+            lpBuffers: self.bufs.as_mut_ptr(),
+            dwBufferCount: self.bufs.len() as u32,
+            Control: WSABUF { len: 0, buf: core::ptr::null_mut() },
+            dwFlags: 0,
+        };
+        let mut recvd: u32 = 0;
+        let ret = unsafe { WSARecvMsg(sock, &mut msg, &mut recvd, core::ptr::null_mut(), None) };
+        if ret == 0 {
+            let addr = unsafe {
+                SockAddr::from_raw_parts(
+                    &storage as *const _ as *const _,
+                    msg.namelen,
+                )
+                .as_socket()
+                .unwrap()
+            };
+            Ok((recvd as i32, addr))
+        } else {
+            Err(io::Error::last_os_error())
+        }
     }
 
     pub fn len(&self) -> usize {

--- a/tests/optimize.rs
+++ b/tests/optimize.rs
@@ -22,6 +22,17 @@ fn memory_pool_reuse() {
     pool.free(block2);
 }
 
+#[cfg(windows)]
+#[test]
+fn zerocopybuffer_basic() {
+    use quicfuscate::optimize::ZeroCopyBuffer;
+    let data1 = [1u8, 2, 3];
+    let data2 = [4u8, 5];
+    let buf = ZeroCopyBuffer::new(&[&data1[..], &data2[..]]);
+    assert_eq!(buf.len(), 5);
+    assert!(!buf.is_empty());
+}
+
 #[test]
 fn xdp_socket_creation() {
     let mgr = OptimizationManager::new();


### PR DESCRIPTION
## Summary
- add per-node memory pool with NUMA bindings
- extend ARM CPU detection and set telemetry mask
- implement Windows zero-copy send/receive helpers
- add basic Windows zero-copy test
- benchmark memory pool allocation

## Testing
- `cargo test --all --quiet` *(fails: build script tries to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686bf7bd51dc8333897c2764e25e5b79