### PR TITLE
Add XDP socket reconfig support and metrics

### DIFF
--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -10,6 +10,10 @@
 //! - `dns_errors_total`: Number of DNS resolution errors.
 //! - `bytes_sent_total`: UDP bytes sent via the core.
 //! - `bytes_received_total`: UDP bytes received via the core.
+//! - `xdp_bytes_sent_total`: Total bytes sent over XDP.
+//! - `xdp_bytes_received_total`: Total bytes received over XDP.
+//! - `xdp_fallback_total`: Number of times XDP fell back to UDP.
+//! - `xdp_active`: Gauge whether XDP is currently active.
 //! - `mem_pool_capacity`: Current capacity of the memory pool.
 //! - `mem_pool_in_use`: Number of blocks currently checked out from the pool.
 //! - `cpu_feature_mask`: Bitmask of detected CPU features.
@@ -52,18 +56,16 @@ lazy_static! {
         register_int_gauge!("mem_pool_in_use", "Memory pool blocks in use").unwrap();
     pub static ref MEM_POOL_USAGE_BYTES: IntGauge =
         register_int_gauge!("mem_pool_usage_bytes", "Memory pool bytes in use").unwrap();
-    pub static ref MEM_POOL_FRAGMENTATION: IntGauge =
-        register_int_gauge!(
-            "mem_pool_fragmentation",
-            "Memory pool fragmentation in blocks"
-        )
-        .unwrap();
-    pub static ref MEM_POOL_UTILIZATION: IntGauge =
-        register_int_gauge!(
-            "mem_pool_utilization_percent",
-            "Memory pool utilization percentage"
-        )
-        .unwrap();
+    pub static ref MEM_POOL_FRAGMENTATION: IntGauge = register_int_gauge!(
+        "mem_pool_fragmentation",
+        "Memory pool fragmentation in blocks"
+    )
+    .unwrap();
+    pub static ref MEM_POOL_UTILIZATION: IntGauge = register_int_gauge!(
+        "mem_pool_utilization_percent",
+        "Memory pool utilization percentage"
+    )
+    .unwrap();
     pub static ref CPU_FEATURE_MASK: IntGauge =
         register_int_gauge!("cpu_feature_mask", "Detected CPU features bitmask").unwrap();
     pub static ref SIMD_ACTIVE: IntGauge =
@@ -82,7 +84,6 @@ lazy_static! {
         register_int_counter!("simd_usage_scalar_total", "Scalar dispatches").unwrap();
     pub static ref PATH_MIGRATIONS: IntCounter =
         register_int_counter!("path_migrations_total", "Successful connection migrations").unwrap();
-
 }
 
 pub fn update_memory_usage() {

--- a/tests/xdp_socket.rs
+++ b/tests/xdp_socket.rs
@@ -1,5 +1,6 @@
 #[cfg(target_os = "linux")]
 mod tests {
+    use quicfuscate::telemetry;
     use quicfuscate::xdp_socket::XdpSocket;
     use std::env;
     use std::net::UdpSocket;
@@ -105,6 +106,42 @@ mod tests {
         let mut buf2 = [0u8; 32];
         let n2 = wait_recv_xdp(&xdp, &mut buf2);
         assert_eq!(&buf2[..n2], reply);
+        env::remove_var("XDP_IFACE");
+    }
+
+    #[test]
+    fn xdp_socket_migrate() {
+        let _guard = VethGuard::setup();
+        env::set_var("XDP_IFACE", "veth-test0");
+        let xdp_addr: std::net::SocketAddr = "10.5.0.1:0".parse().unwrap();
+
+        let udp1 = UdpSocket::bind("10.5.0.2:0").unwrap();
+        udp1.connect(xdp_addr).unwrap();
+        udp1.set_nonblocking(true).unwrap();
+        let udp1_addr = udp1.local_addr().unwrap();
+
+        let mut xdp = XdpSocket::new(xdp_addr, udp1_addr).unwrap();
+        let start = telemetry::XDP_BYTES_SENT.get();
+
+        let msg = b"first";
+        assert_eq!(xdp.send(&[msg.as_ref()]).unwrap(), msg.len());
+        let mut buf = [0u8; 32];
+        let n = wait_recv(&udp1, &mut buf);
+        assert_eq!(&buf[..n], msg);
+
+        let udp2 = UdpSocket::bind("10.5.0.2:0").unwrap();
+        udp2.connect(xdp_addr).unwrap();
+        udp2.set_nonblocking(true).unwrap();
+        let udp2_addr = udp2.local_addr().unwrap();
+        xdp.update_remote(udp2_addr).unwrap();
+
+        let msg2 = b"second";
+        assert_eq!(xdp.send(&[msg2.as_ref()]).unwrap(), msg2.len());
+        let mut buf2 = [0u8; 32];
+        let n2 = wait_recv(&udp2, &mut buf2);
+        assert_eq!(&buf2[..n2], msg2);
+
+        assert!(telemetry::XDP_BYTES_SENT.get() >= start + (msg.len() + msg2.len()) as u64);
         env::remove_var("XDP_IFACE");
     }
 }


### PR DESCRIPTION
## Summary
- support reconfiguring XDP sockets when migrating connections
- export more XDP metrics in telemetry docs
- add CLI option to print live XDP statistics
- extend XDP socket tests with migration scenario

## Testing
- `cargo test --all --quiet` *(fails: Quiche workflow requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686bf7b9ec2083338fedba3401bdd701