### PR TITLE
Add FEC telemetry metrics and PID config

### DIFF
--- a/benches/fec_modes.rs
+++ b/benches/fec_modes.rs
@@ -1,0 +1,48 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use quicfuscate::fec::{AdaptiveFec, FecConfig, FecMode, Packet};
+use quicfuscate::optimize::MemoryPool;
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+fn bench_fec_modes(c: &mut Criterion) {
+    let pool = Arc::new(MemoryPool::new(2048, 2048));
+    let mut data_block = pool.alloc();
+    for b in data_block.iter_mut() {
+        *b = 0xAB;
+    }
+    let base_packet = Packet {
+        id: 0,
+        data: Some(data_block),
+        len: 1024,
+        is_systematic: true,
+        coefficients: None,
+        coeff_len: 0,
+        mem_pool: Arc::clone(&pool),
+    };
+
+    for mode in [
+        FecMode::Light,
+        FecMode::Normal,
+        FecMode::Medium,
+        FecMode::Strong,
+    ] {
+        c.bench_with_input(
+            BenchmarkId::new("send", format!("{:?}", mode)),
+            &mode,
+            |b, &m| {
+                let mut cfg = FecConfig::default();
+                cfg.initial_mode = m;
+                let mut fec = AdaptiveFec::new(cfg, Arc::clone(&pool));
+                let mut q = VecDeque::new();
+                b.iter(|| {
+                    let pkt = base_packet.clone_for_encoder(&pool);
+                    fec.on_send(pkt, &mut q);
+                    q.clear();
+                });
+            },
+        );
+    }
+}
+
+criterion_group!(fec_mode_benches, bench_fec_modes);
+criterion_main!(fec_mode_benches);

--- a/src/fec/decoder.rs
+++ b/src/fec/decoder.rs
@@ -604,6 +604,7 @@ impl Decoder {
     fn gaussian_elimination(&mut self) -> bool {
         // This is a simplified sparse implementation. A truly high-performance version
         // would require more complex data structures and operations to minimize cache misses.
+        let start = std::time::Instant::now();
         let k = self.k;
         let mut rank = 0;
 
@@ -661,6 +662,7 @@ impl Decoder {
                 }
             }
         }
+        telemetry::DECODING_TIME_MS.set(start.elapsed().as_millis() as i64);
         true
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -6,6 +6,8 @@
 //! - `loss_rate_percent`: Current estimated loss rate multiplied by 100.
 //! - `fec_mode`: Active FEC mode as numeric value.
 //! - `fec_mode_switch_total`: Number of FEC mode transitions.
+//! - `fec_window_size`: Current FEC window size.
+//! - `decoding_time_ms`: Time spent in the last decode run in milliseconds.
 //! - `fec_overflow_total`: Number of times the FEC memory pool had to allocate
 //!   a new block because the pool was exhausted.
 //! - `dns_errors_total`: Number of DNS resolution errors.
@@ -36,6 +38,10 @@ lazy_static! {
         register_int_gauge!("fec_mode", "Current FEC mode").unwrap();
     pub static ref FEC_MODE_SWITCHES: IntCounter =
         register_int_counter!("fec_mode_switch_total", "FEC mode transitions").unwrap();
+    pub static ref FEC_WINDOW: IntGauge =
+        register_int_gauge!("fec_window_size", "Current FEC window size").unwrap();
+    pub static ref DECODING_TIME_MS: IntGauge =
+        register_int_gauge!("decoding_time_ms", "Last decoder runtime in ms").unwrap();
     pub static ref FEC_OVERFLOWS: IntCounter =
         register_int_counter!("fec_overflow_total", "FEC memory pool overflows").unwrap();
     pub static ref DNS_ERRORS: IntCounter =


### PR DESCRIPTION
## Summary
- export new `fec_window_size` and `decoding_time_ms` metrics
- update FEC PID defaults to values in PLAN.txt
- expose current window size in adaptive FEC logic
- periodically flush metrics from the core connection
- add benchmark for different FEC modes

## Testing
- `cargo test --no-run --quiet` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686c005015cc83339849b8fc800805bb