### PR TITLE
Enable custom TLS loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,8 +1470,10 @@ dependencies = [
  "hex",
  "lazy_static",
  "libc",
+ "libloading",
  "log",
  "morus",
+ "once_cell",
  "prometheus",
  "quiche",
  "rand 0.8.5",
@@ -1476,6 +1488,7 @@ dependencies = [
  "tokio",
  "toml",
  "url",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ xdp = ["afxdp"]
 [dev-dependencies]
 hex="0.4"
 criterion="0.5"
+once_cell="1.19"

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -447,6 +447,19 @@ let tls_params = fingerprint.generate_tls_parameters();
    - Emulates TLS 1.3 handshake characteristics
 4. **Fingerprint Customization**:
    - Adjustable browser and OS types
+
+### Adding new Browser Fingerprints
+Real TLS ClientHello bytes are stored in `browser_profiles/` with the file name
+format `<browser>_<os>.chlo`. The content must be base64 encoded. To add a new
+fingerprint:
+
+1. Capture the ClientHello bytes using your preferred tooling.
+2. Encode the raw bytes with base64 and save them as
+   `browser_profiles/<browser>_<os>.chlo`.
+3. Rebuild the patched quiche library using `scripts/quiche_workflow.sh --step patch`.
+4. Run the unit tests with `cargo test` to verify the fingerprint is loaded
+   correctly.
+
 ### HTTP Header Spoofing
 Defined in `stealth/browser_profiles/headers/FakeHeaders.rs`:
 

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -180,12 +180,13 @@ pub struct FingerprintProfile {
     pub initial_max_stream_data_bidi_remote: u64,
     pub initial_max_streams_bidi: u64,
     pub max_idle_timeout: u64,
+    pub client_hello: Option<Vec<u8>>,
 }
 
 impl FingerprintProfile {
     /// Creates a new profile for a given browser and OS combination, with harmonized values.
     pub fn new(browser: BrowserProfile, os: OsProfile) -> Self {
-        match (browser, os) {
+        let mut profile = match (browser, os) {
             // --- Windows Profiles ---
             (BrowserProfile::Chrome, OsProfile::Windows) => Self {
                 browser, os,
@@ -197,6 +198,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
            (BrowserProfile::Firefox, OsProfile::Windows) => Self {
                 browser, os,
@@ -208,6 +210,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_048_576,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 60_000,
+                client_hello: None,
             },
            (BrowserProfile::Opera, OsProfile::Windows) => Self {
                browser, os,
@@ -219,6 +222,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Brave, OsProfile::Windows) => Self {
                browser, os,
@@ -230,6 +234,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Edge, OsProfile::Windows) => Self {
                browser, os,
@@ -241,6 +246,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Edge, OsProfile::MacOS) => Self {
                browser, os,
@@ -252,6 +258,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Edge, OsProfile::Linux) => Self {
                browser, os,
@@ -263,6 +270,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Vivaldi, OsProfile::Windows) => Self {
                browser, os,
@@ -274,6 +282,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Vivaldi, OsProfile::MacOS) => Self {
                browser, os,
@@ -285,6 +294,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
            (BrowserProfile::Vivaldi, OsProfile::Linux) => Self {
                browser, os,
@@ -296,6 +306,7 @@ impl FingerprintProfile {
                initial_max_stream_data_bidi_remote: 1_000_000,
                initial_max_streams_bidi: 100,
                max_idle_timeout: 30_000,
+                client_hello: None,
            },
             // --- macOS Profiles ---
            (BrowserProfile::Safari, OsProfile::MacOS) => Self {
@@ -308,6 +319,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 2_097_152,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 45_000,
+                client_hello: None,
             },
             (BrowserProfile::Chrome, OsProfile::MacOS) => Self {
                 browser, os,
@@ -319,6 +331,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Opera, OsProfile::MacOS) => Self {
                 browser, os,
@@ -330,6 +343,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Brave, OsProfile::MacOS) => Self {
                 browser, os,
@@ -341,6 +355,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Firefox, OsProfile::MacOS) => Self {
                 browser, os,
@@ -352,6 +367,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_048_576,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 60_000,
+                client_hello: None,
             },
             (BrowserProfile::Chrome, OsProfile::Linux) => Self {
                 browser, os,
@@ -363,6 +379,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Opera, OsProfile::Linux) => Self {
                 browser, os,
@@ -374,6 +391,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Brave, OsProfile::Linux) => Self {
                 browser, os,
@@ -385,6 +403,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_000_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Firefox, OsProfile::Linux) => Self {
                 browser, os,
@@ -396,6 +415,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 1_048_576,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 60_000,
+                client_hello: None,
             },
             (BrowserProfile::Chrome, OsProfile::Android) => Self {
                 browser, os,
@@ -407,6 +427,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Firefox, OsProfile::Android) => Self {
                 browser, os,
@@ -418,6 +439,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Opera, OsProfile::Android) => Self {
                 browser, os,
@@ -429,6 +451,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Brave, OsProfile::Android) => Self {
                 browser, os,
@@ -440,6 +463,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Edge, OsProfile::Android) => Self {
                 browser, os,
@@ -451,6 +475,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Vivaldi, OsProfile::Android) => Self {
                 browser, os,
@@ -462,6 +487,7 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             (BrowserProfile::Safari, OsProfile::IOS) => Self {
                 browser, os,
@@ -473,10 +499,14 @@ impl FingerprintProfile {
                 initial_max_stream_data_bidi_remote: 500_000,
                 initial_max_streams_bidi: 100,
                 max_idle_timeout: 30_000,
+                client_hello: None,
             },
             // --- Fallback Profile ---
             _ => Self::new(BrowserProfile::Chrome, OsProfile::Windows),
-        }
+        };
+
+        profile.client_hello = TlsClientHelloSpoofer::load_client_hello(browser, os);
+        profile
     }
 
     /// Generates a set of realistic HTTP headers based on the profile.
@@ -816,26 +846,28 @@ impl TlsClientHelloSpoofer {
 
     /// Apply the spoofing parameters using a custom ClientHello from
     /// `browser_profiles`.
-    pub fn apply(
-        config: &mut quiche::Config,
-        browser: BrowserProfile,
-        os: OsProfile,
-        suites: &[u16],
-    ) {
+    pub fn apply(config: &mut quiche::Config, profile: &FingerprintProfile, suites: &[u16]) {
         debug!(
             "uTLS: manipulating ClientHello for {:?}/{:?} with {} suites",
-            browser,
-            os,
+            profile.browser,
+            profile.os,
             suites.len()
         );
 
-        // Load a pre-recorded ClientHello from disk.
-        let hello = match Self::load_client_hello(browser, os) {
-            Some(h) => h,
-            None => {
-                error!("Missing ClientHello profile for {:?}/{:?}", browser, os);
-                return;
-            }
+        // Use preloaded ClientHello from the profile if available.
+        let hello = match &profile.client_hello {
+            Some(h) => h.clone(),
+            None => match Self::load_client_hello(profile.browser, profile.os) {
+                Some(h) => h,
+                None => {
+                    error!(
+                        "Missing ClientHello profile for {:?}/{:?}",
+                        profile.browser,
+                        profile.os
+                    );
+                    return;
+                }
+            },
         };
         unsafe {
             extern "C" {
@@ -1031,7 +1063,7 @@ impl StealthManager {
                 error!("Failed to set custom cipher suites: {}", e);
             }
             // Manipulate TLS ClientHello to match the desired ordering.
-            TlsClientHelloSpoofer::apply(config, fingerprint.browser, fingerprint.os, &suite_ids);
+            TlsClientHelloSpoofer::apply(config, &fingerprint, &suite_ids);
         }
 
         config

--- a/tests/tls_ffi.rs
+++ b/tests/tls_ffi.rs
@@ -1,0 +1,10 @@
+use quicfuscate::tls_ffi::{quiche_config_set_custom_tls, LAST_HELLO};
+use std::os::raw::c_void;
+
+#[test]
+fn ffi_records_clienthello_bytes() {
+    let data = [0u8, 1, 2, 3];
+    unsafe { quiche_config_set_custom_tls(std::ptr::null_mut::<c_void>(), data.as_ptr(), data.len()); }
+    let stored = LAST_HELLO.lock().unwrap().clone();
+    assert_eq!(stored, data);
+}


### PR DESCRIPTION
## Summary
- support recording last ClientHello in TLS FFI stub
- allow fingerprint profiles to hold raw ClientHello bytes
- load ClientHello files from `browser_profiles` and apply via FFI
- document how to add new fingerprint dumps
- add unit test checking stub behaviour

## Testing
- `cargo check` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686c004ee5748333a984d75807facf7e