### PR TITLE
Add dynamic XDP socket reconfiguration

### DIFF
--- a/docs/issues/003-xdp-zero-copy.md
+++ b/docs/issues/003-xdp-zero-copy.md
@@ -15,9 +15,14 @@ possible.
 
 ## Kernel & System Setup
 
-The benchmarks require a recent Linux kernel (5.15+) with `CONFIG_XDP_SOCKETS` enabled.
-`libbpf-dev` must be installed and the user running the tests needs `CAP_NET_ADMIN`.
-For reliable zero-copy operation increase locked memory limits, e.g.
+The benchmarks require a recent Linux kernel (5.15+) with the following options
+compiled in:
+
+- `CONFIG_BPF` and `CONFIG_BPF_SYSCALL`
+- `CONFIG_XDP_SOCKETS`
+
+Install `libbpf-dev` and ensure the test user has `CAP_NET_ADMIN`.  To avoid
+packet drops when using zero-copy, raise the locked memory limit:
 
 ```bash
 sudo ulimit -l unlimited

--- a/src/core.rs
+++ b/src/core.rs
@@ -456,9 +456,19 @@ impl QuicFuscateConnection {
                 quiche::PathEvent::Validated(local, peer) => {
                     println!("Path validated: {local}->{peer}");
                     self.peer_addr = peer;
-                    self.xdp_socket = self
-                        .optimization_manager
-                        .create_xdp_socket(self.local_addr, peer);
+                    self.local_addr = local;
+                    if let Some(ref mut xdp) = self.xdp_socket {
+                        if let Err(e) = xdp.reconfigure(local, peer) {
+                            eprintln!("XDP reconfigure failed: {e}");
+                            self.xdp_socket = self
+                                .optimization_manager
+                                .create_xdp_socket(local, peer);
+                        }
+                    } else {
+                        self.xdp_socket = self
+                            .optimization_manager
+                            .create_xdp_socket(local, peer);
+                    }
                     telemetry::PATH_MIGRATIONS.inc();
                 }
                 quiche::PathEvent::FailedValidation(local, peer) => {
@@ -473,9 +483,19 @@ impl QuicFuscateConnection {
                 quiche::PathEvent::PeerMigrated(local, peer) => {
                     println!("Peer migrated: {local}->{peer}");
                     self.peer_addr = peer;
-                    self.xdp_socket = self
-                        .optimization_manager
-                        .create_xdp_socket(self.local_addr, peer);
+                    self.local_addr = local;
+                    if let Some(ref mut xdp) = self.xdp_socket {
+                        if let Err(e) = xdp.reconfigure(local, peer) {
+                            eprintln!("XDP reconfigure failed: {e}");
+                            self.xdp_socket = self
+                                .optimization_manager
+                                .create_xdp_socket(local, peer);
+                        }
+                    } else {
+                        self.xdp_socket = self
+                            .optimization_manager
+                            .create_xdp_socket(local, peer);
+                    }
                     telemetry::PATH_MIGRATIONS.inc();
                 }
             }

--- a/src/xdp_socket.rs
+++ b/src/xdp_socket.rs
@@ -141,6 +141,7 @@ impl XdpSocket {
             Ok(v) => v,
             Err(_) => {
                 telemetry::XDP_FALLBACKS.inc();
+                telemetry::XDP_ACTIVE.set(0);
                 self.udp = udp;
                 return Ok(());
             }
@@ -153,6 +154,7 @@ impl XdpSocket {
             Ok(v) => v,
             Err(_) => {
                 telemetry::XDP_FALLBACKS.inc();
+                telemetry::XDP_ACTIVE.set(0);
                 self.udp = udp;
                 return Ok(());
             }
@@ -169,6 +171,7 @@ impl XdpSocket {
             Ok(v) => v,
             Err(_) => {
                 telemetry::XDP_FALLBACKS.inc();
+                telemetry::XDP_ACTIVE.set(0);
                 self.udp = udp;
                 return Ok(());
             }
@@ -184,6 +187,7 @@ impl XdpSocket {
             pool: bufs,
             pending: ArrayDeque::new(),
         });
+        telemetry::XDP_ACTIVE.set(1);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- enable XDP socket reconfiguration on path migration
- update XDP telemetry when sockets are recreated
- document kernel requirements for AF_XDP zero-copy

## Testing
- `cargo fmt -- --check`
- `cargo test --all --no-run` *(fails: patch verification errors)*

------
https://chatgpt.com/codex/tasks/task_e_686c069e1adc8333b67b370702cf375b