### PR TITLE
Add central config validation and telemetry

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -95,7 +95,8 @@ quicfuscate server \
 
 ### Example Configuration
 
-The file `docs/example_config.toml` demonstrates how to tune the adaptive engine:
+The unified configuration file combines FEC tuning with stealth and optimization
+options. Below is the content of `docs/example_config.toml`:
 
 ```toml
 [adaptive_fec]
@@ -110,9 +111,21 @@ kalman_r = 0.02
 name = "light"
 w0 = 20
 
-[[adaptive_fec.modes]]
-name = "extreme"
-w0 = 2048
+[stealth]
+browser_profile = "chrome"
+os_profile = "windows"
+enable_doh = true
+doh_provider = "https://cloudflare-dns.com/dns-query"
+enable_domain_fronting = true
+fronting_domains = ["cdn.example.com"]
+enable_xor_obfuscation = true
+enable_http3_masquerading = true
+use_qpack_headers = true
+
+[optimize]
+pool_capacity = 1024
+block_size = 4096
+enable_xdp = false
 ```
 
 ### Connection Migration

--- a/docs/example_config.toml
+++ b/docs/example_config.toml
@@ -18,6 +18,8 @@ doh_provider = "https://cloudflare-dns.com/dns-query"
 enable_domain_fronting = true
 fronting_domains = ["cdn.example.com"]
 enable_xor_obfuscation = true
+enable_http3_masquerading = true
+use_qpack_headers = true
 
 [optimize]
 pool_capacity = 1024

--- a/src/fec/adaptive.rs
+++ b/src/fec/adaptive.rs
@@ -498,6 +498,10 @@ impl AdaptiveFec {
             config,
         };
         telemetry::FEC_WINDOW.set(mode_mgr.current_window as i64);
+        telemetry::FEC_LAMBDA.set((config.lambda * 1000.0) as i64);
+        telemetry::FEC_BURST_WINDOW.set(config.burst_window as i64);
+        telemetry::FEC_HYSTERESIS.set((config.hysteresis * 1000.0) as i64);
+        telemetry::FEC_KALMAN.set(if config.kalman_enabled { 1 } else { 0 });
         this
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
+use crate::app_config::AppConfig;
 use crate::core::QuicFuscateConnection;
 use crate::fec::{FecConfig, FecMode};
-use crate::app_config::AppConfig;
+use crate::optimize::OptimizeConfig;
 #[cfg(unix)]
 use crate::optimize::ZeroCopyBuffer;
-use crate::optimize::OptimizeConfig;
 use crate::stealth::StealthConfig;
 use crate::stealth::{BrowserProfile, FingerprintProfile, OsProfile};
 use crate::telemetry;
@@ -427,13 +427,22 @@ async fn run_client(
             }
             Err(e) => {
                 error!("Failed to load config {}: {}", cfg.display(), e);
-                (FecConfig::default(), StealthConfig::default(), OptimizeConfig::default())
+                (
+                    FecConfig::default(),
+                    StealthConfig::default(),
+                    OptimizeConfig::default(),
+                )
             }
         }
     } else {
         let mut fec = if let Some(path) = fec_config {
             match FecConfig::from_file(path) {
-                Ok(cfg) => cfg,
+                Ok(cfg) => {
+                    if let Err(e) = cfg.validate() {
+                        warn!("FEC config validation failed: {}", e);
+                    }
+                    cfg
+                }
                 Err(e) => {
                     error!("Failed to load FEC config {}: {}", path.display(), e);
                     FecConfig::default()
@@ -688,13 +697,22 @@ async fn run_server(
             }
             Err(e) => {
                 error!("Failed to load config {}: {}", cfg.display(), e);
-                (FecConfig::default(), StealthConfig::default(), OptimizeConfig::default())
+                (
+                    FecConfig::default(),
+                    StealthConfig::default(),
+                    OptimizeConfig::default(),
+                )
             }
         }
     } else {
         let mut fec = if let Some(path) = fec_config {
             match FecConfig::from_file(path) {
-                Ok(cfg) => cfg,
+                Ok(cfg) => {
+                    if let Err(e) = cfg.validate() {
+                        warn!("FEC config validation failed: {}", e);
+                    }
+                    cfg
+                }
                 Err(e) => {
                     error!("Failed to load FEC config {}: {}", path.display(), e);
                     FecConfig::default()

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -862,8 +862,7 @@ impl TlsClientHelloSpoofer {
                 None => {
                     error!(
                         "Missing ClientHello profile for {:?}/{:?}",
-                        profile.browser,
-                        profile.os
+                        profile.browser, profile.os
                     );
                     return;
                 }
@@ -986,7 +985,10 @@ impl StealthConfig {
         if self.enable_doh && self.doh_provider.is_empty() {
             return Err("doh_provider must not be empty when DoH is enabled".into());
         }
-        if self.enable_domain_fronting && self.fronting_domains.is_empty() && self.cdn_providers.is_empty() {
+        if self.enable_domain_fronting
+            && self.fronting_domains.is_empty()
+            && self.cdn_providers.is_empty()
+        {
             return Err("fronting_domains required when domain fronting is enabled".into());
         }
         Ok(())
@@ -1031,6 +1033,10 @@ impl StealthManager {
         } else {
             None
         };
+
+        telemetry::STEALTH_DOH.set(if config.enable_doh { 1 } else { 0 });
+        telemetry::STEALTH_FRONTING.set(if config.enable_domain_fronting { 1 } else { 0 });
+        telemetry::STEALTH_XOR.set(if config.enable_xor_obfuscation { 1 } else { 0 });
 
         Self {
             config,

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -111,6 +111,20 @@ lazy_static! {
         register_int_gauge!("stealth_os_profile", "Active OS profile").unwrap();
     pub static ref PATH_MIGRATIONS: IntCounter =
         register_int_counter!("path_migrations_total", "Successful connection migrations").unwrap();
+    pub static ref FEC_LAMBDA: IntGauge =
+        register_int_gauge!("fec_lambda_scaled", "FEC lambda * 1000").unwrap();
+    pub static ref FEC_BURST_WINDOW: IntGauge =
+        register_int_gauge!("fec_burst_window", "FEC burst window").unwrap();
+    pub static ref FEC_HYSTERESIS: IntGauge =
+        register_int_gauge!("fec_hysteresis_scaled", "FEC hysteresis * 1000").unwrap();
+    pub static ref FEC_KALMAN: IntGauge =
+        register_int_gauge!("fec_kalman_enabled", "Kalman filter enabled").unwrap();
+    pub static ref STEALTH_DOH: IntGauge =
+        register_int_gauge!("stealth_doh", "DNS-over-HTTPS enabled").unwrap();
+    pub static ref STEALTH_FRONTING: IntGauge =
+        register_int_gauge!("stealth_fronting", "Domain fronting enabled").unwrap();
+    pub static ref STEALTH_XOR: IntGauge =
+        register_int_gauge!("stealth_xor", "XOR obfuscation enabled").unwrap();
 }
 
 pub fn update_memory_usage() {


### PR DESCRIPTION
## Summary
- add stealth options in example config and document them in USAGE.md
- track FEC/stealth parameters via new telemetry gauges
- validate FEC config when loaded separately

## Testing
- `cargo fmt -- src/fec/adaptive.rs src/main.rs src/stealth.rs src/telemetry.rs`
- `cargo test --quiet` *(fails: could not compile `quicfuscate` due to missing patched quiche sources)*

------
https://chatgpt.com/codex/tasks/task_e_686c069e1af08333b5ad76c2836c4d44