### PR TITLE
Add quiche submodule update instructions

### DIFF
--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -255,6 +255,16 @@ The `scripts/quiche_workflow.sh` script provides a complete local development wo
    ./scripts/maintain_quiche.sh patch
    ```
 
+4. **Submodule Update**:
+   Update the embedded quiche sources to the latest upstream commit and store the
+   new state in version control:
+   ```bash
+   git submodule update --remote libs/patched_quiche
+   git add libs/patched_quiche
+   git commit -m "Update quiche submodule"
+   ```
+   Verify afterwards that all patches still apply and the build succeeds.
+
 ### Version Control
 
 - All changes to quiche must be tracked in git


### PR DESCRIPTION
## Summary
- clarify submodule update procedure in `Quiche_Dependency.md`

## Testing
- `cargo test` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686c347214e483338fb8f03e65a6b464