### PR TITLE
Add custom ClientHello support hooks

### DIFF
--- a/libs/patches/boringssl_clienthello_hook.patch
+++ b/libs/patches/boringssl_clienthello_hook.patch
@@ -1,0 +1,19 @@
+--- a/deps/boringssl/ssl/handshake_client.cc
++++ b/deps/boringssl/ssl/handshake_client.cc
+@@
+ bool ssl_add_client_hello(SSL_HANDSHAKE *hs) {
+   SSL *const ssl = hs->ssl;
++  if (!ssl->custom_client_hello.empty()) {
++    Array<uint8_t> msg;
++    if (!msg.CopyFrom(bssl::Span<const uint8_t>(
++            ssl->custom_client_hello.data(),
++            ssl->custom_client_hello.size()))) {
++      return false;
++    }
++    return ssl->method->add_message(ssl, std::move(msg));
++  }
+   ScopedCBB cbb;
+   CBB body;
+   ssl_client_hello_type_t type = hs->selected_ech_config
+                                      ? ssl_client_hello_outer
+                                      : ssl_client_hello_unencrypted;

--- a/libs/patches/series
+++ b/libs/patches/series
@@ -1,0 +1,5 @@
+boringssl_custom_hello.patch
+boringssl_clienthello_hook.patch
+custom_tls.patch
+simd_optimizations.patch
+readme_quicfuscate.patch

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -491,7 +491,8 @@ main() {
         log "Starte kompletten Workflow..."
         
         # Definiere die Reihenfolge der Schritte
-        local steps_order=("fetch" "patch" "verify_patches" "build" "test")
+        # Die Patch-Verifikation erfolgt nun automatisch in apply_patches
+        local steps_order=("fetch" "patch" "build" "test")
         
         # Führe jeden Schritt aus
         for step in "${steps_order[@]}"; do

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -53,7 +53,7 @@ use url::Url;
 use crate::crypto::CryptoManager; // Assumed for integration
 use crate::optimize::{self, OptimizationManager}; // Assumed for integration
 use crate::telemetry;
-use std::os::raw::c_void;
+use crate::tls_ffi;
 
 // --- Global Tokio Runtime for async DoH requests ---
 lazy_static! {
@@ -869,11 +869,8 @@ impl TlsClientHelloSpoofer {
             },
         };
         unsafe {
-            extern "C" {
-                fn quiche_config_set_custom_tls(cfg: *mut c_void, hello: *const u8, len: usize);
-            }
-            quiche_config_set_custom_tls(
-                config as *mut _ as *mut c_void,
+            tls_ffi::quiche_config_set_custom_tls(
+                config as *mut _ as *mut std::ffi::c_void,
                 hello.as_ptr(),
                 hello.len(),
             );


### PR DESCRIPTION
## Summary
- add patch to hook BoringSSL's client hello for custom messages
- enforce patch order via series file
- update workflow script to simplify step order
- load fingerprints via tls_ffi API

## Testing
- `cargo test` *(fails: failed to run custom build command)*

------
https://chatgpt.com/codex/tasks/task_e_686c3a3479888333a262a2d1e756c926