### PR TITLE
Implement migrate telemetry + docs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -137,6 +137,7 @@ To migrate an established connection to a new local port, call `migrate_connecti
 
 ```rust
 let new_addr = "127.0.0.1:0".parse().unwrap();
-conn.migrate_connection(new_addr).unwrap();
+let path_id = conn.migrate_connection(new_addr).unwrap();
+println!("migrated to path {path_id}");
 ```
 The library records successful migrations via the `path_migrations_total` telemetry counter.

--- a/src/core.rs
+++ b/src/core.rs
@@ -338,7 +338,11 @@ impl QuicFuscateConnection {
             telemetry!(telemetry::XDP_ACTIVE.set(0));
         }
 
-        self.conn.migrate(self.local_addr, new_peer)
+        let res = self.conn.migrate(self.local_addr, new_peer);
+        if res.is_ok() {
+            telemetry!(telemetry::PATH_MIGRATIONS.inc());
+        }
+        res
     }
 
     /// Returns the Host header that should be used for HTTP requests when domain


### PR DESCRIPTION
## Summary
- add path migration metric increment on successful migration
- expand usage guide with path migration example

## Testing
- `cargo test --no-run --quiet` *(fails: command blocked or timed out)*

------
https://chatgpt.com/codex/tasks/task_e_686c535efa3c833390f348835d0d1fb2