### PR TITLE
Remove duplicate XDP args

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -86,14 +86,6 @@ enum Commands {
         #[clap(long)]
         xdp_stats: bool,
 
-        /// Enable XDP acceleration if supported
-        #[clap(long)]
-        xdp: bool,
-
-        /// Print live XDP statistics
-        #[clap(long)]
-        xdp_stats: bool,
-
         /// Path to a unified TOML configuration file
         #[clap(long, value_name = "PATH")]
         config: Option<PathBuf>,


### PR DESCRIPTION
## Summary
- remove duplicate `xdp` and `xdp_stats` options from `Cli`

## Testing
- `cargo check` *(fails: patching of quiche submodule requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_686cc0a45f948333a5574752b276ca1f