### PR TITLE
Add non-interactive option to workflow

### DIFF
--- a/.github/workflows/build-quiche.yml
+++ b/.github/workflows/build-quiche.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Run quiche workflow
       run: |
         chmod +x ./scripts/quiche_workflow.sh
-        ./scripts/quiche_workflow.sh --type ${{ inputs.build_type || 'release' }}
+        ./scripts/quiche_workflow.sh --non-interactive --type ${{ inputs.build_type || 'release' }}
 
     - name: Verify quiche artifacts
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Fetch and build quiche
         shell: bash
         run: |
-          ./scripts/quiche_workflow.sh --step fetch
+          ./scripts/quiche_workflow.sh --non-interactive --step fetch
 
       - name: Ensure QUICHE_PATH
         shell: bash

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -43,6 +43,9 @@ check_internet() {
 
 # Fragt den Benutzer, ob ein Vorgang wiederholt werden soll
 ask_retry() {
+    if [[ "${NON_INTERACTIVE:-}" == "1" ]]; then
+        return 1
+    fi
     read -r -p "Erneut versuchen? [j/N] " answer
     [[ "$answer" =~ ^[Jj]$ ]]
 }
@@ -67,6 +70,7 @@ LOG_DIR="$LIBS_DIR/logs"
 STATE_FILE="$BASE_DIR/.quiche_workflow_state"
 BUILD_TYPE="release"
 MIRROR_URL="https://github.com/cloudflare/quiche.git"
+NON_INTERACTIVE="${NON_INTERACTIVE:-0}"
 
 # Make quiche available to Cargo
 export QUICHE_PATH="$PATCHED_DIR/quiche"
@@ -403,6 +407,8 @@ show_help() {
     echo "  -t, --type TYPE     Build-Typ (release|debug), Standard: release"
     echo "  -m, --mirror URL    Git-Repository-URL für quiche"
     echo "  -s, --step SCHRITT  Bestimmten Schritt ausführen (fetch|patch|verify_patches|build|test)"
+    echo "  -n, --non-interactive  Nicht interaktiv ausführen (Abbruch bei Fehlern)"
+    echo "                        oder NON_INTERACTIVE=1 setzen"
     echo "  -h, --help          Zeige diese Hilfe"
     echo
     echo "Verfügbare Schritte:"
@@ -442,6 +448,10 @@ main() {
                 fi
                 START_STEP="$2"
                 shift 2
+                ;;
+            --non-interactive|-n)
+                NON_INTERACTIVE=1
+                shift
                 ;;
             --help|-h)
                 show_help


### PR DESCRIPTION
## Summary
- add `--non-interactive` option to `quiche_workflow.sh`
- use the new flag in build and CI workflows

## Testing
- `cargo test --quiet` *(fails: Quiche workflow failed)*

------
https://chatgpt.com/codex/tasks/task_e_686cc0a48bf4833392acbbe69a516969