### PR TITLE
Implement fingerprint loading and listing

### DIFF
--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -287,6 +287,8 @@ apply_patches() {
         if ! verify_patches; then
             patch_failure "Patch-Verifikation fehlgeschlagen" "$backup_dir"
         fi
+        # Rebuild BoringSSL hooks to ensure patched symbols are available
+        run_command "BoringSSL hooks build" "(cd \"$PATCHED_DIR\" && cargo build --release -p quiche --lib)"
     else
         warn "Keine Patch-Dateien im .patch-Format gefunden"
     fi


### PR DESCRIPTION
## Summary
- enumerate available ClientHello dumps for TLS fingerprinting
- switch to loading fingerprints per profile change
- list actual fingerprints in demo CLI
- ensure patched BoringSSL hooks are compiled when patching quiche

## Testing
- `cargo test` *(fails: could not compile `quicfuscate` due to errors)*

------
https://chatgpt.com/codex/tasks/task_e_686cc54169c483338b38200d96c3103d