### PR TITLE
Enable SSE2 bitsliced GF kernels

### DIFF
--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -388,10 +388,16 @@ where
         && detector.has_feature(CpuFeature::PCLMULQDQ)
     {
         f(&Avx512)
-    } else if detector.has_feature(CpuFeature::AVX2) && detector.has_feature(CpuFeature::PCLMULQDQ)
+    } else if detector.has_feature(CpuFeature::AVX2)
+        && detector.has_feature(CpuFeature::PCLMULQDQ)
     {
         f(&Avx2)
-    } else if detector.has_feature(CpuFeature::NEON) && detector.has_feature(CpuFeature::PCLMULQDQ)
+    } else if detector.has_feature(CpuFeature::SSE2)
+        && detector.has_feature(CpuFeature::PCLMULQDQ)
+    {
+        f(&Sse2)
+    } else if detector.has_feature(CpuFeature::NEON)
+        && detector.has_feature(CpuFeature::PCLMULQDQ)
     {
         f(&Neon)
     } else {


### PR DESCRIPTION
## Summary
- add SSE2 bit-sliced multiplication kernel
- enable SSE2+PCLMULQDQ detection for bit-sliced dispatch
- benchmark SSE2 kernel alongside AVX2/AVX512/NEON

## Testing
- `cargo bench --bench gf_bitslice_bench --no-run` *(fails: Quiche workflow requires network)*

------
https://chatgpt.com/codex/tasks/task_e_686cc548d9e48333b00121c2ec9cb9b7