### PR TITLE
Implement custom ClientHello injection

### DIFF
--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -161,8 +161,15 @@ When the patched library is absent, a stub implementation lives in
 
 Real ClientHello messages are stored as base64 files in `browser_profiles/*.chlo`.
 `StealthManager` loads the corresponding file and injects the bytes via
-`quiche_config_set_custom_tls`. After adding new fingerprints, rebuild the
-patched library with `scripts/quiche_workflow.sh --type release`.
+`quiche_config_set_custom_tls`.
+
+### Neue Fingerprints erstellen
+
+1. Zeichne den TLS-Handshake des Zielbrowsers z.B. mit Wireshark auf.
+2. Extrahiere den kompletten ClientHello-Buffer und kodieren ihn mit `base64`.
+3. Speichere die Daten als `<browser>_<os>.chlo` unter `browser_profiles/`.
+4. Führe anschließend `scripts/quiche_workflow.sh --type release` aus, um die
+   gepatchte Bibliothek mit den neuen Profilen neu zu bauen.
 
 ## Advanced Optimizations
 


### PR DESCRIPTION
## Summary
- load ClientHello profiles at compile time in `stealth.rs`
- inject the buffer via `quiche_config_set_custom_tls`
- fix patch workflow to handle quiche and BoringSSL patches
- document how to create new fingerprints

## Testing
- `cargo test --quiet` *(fails: patch verification could not run)*

------
https://chatgpt.com/codex/tasks/task_e_686cd7010ad083338d81a9c8e9167d68