### PR TITLE
Improve quiche workflow docs and checks

### DIFF
--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -21,6 +21,15 @@ Clone the repository and run the workflow to download, patch and build quiche:
 ./scripts/quiche_workflow.sh --type release
 ```
 
+After completion the environment variable `QUICHE_PATH` points to the patched
+sources under `libs/patched_quiche/quiche`. Use it when building other
+components:
+
+```bash
+export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche
+cargo build --release
+```
+
 The workflow fetches the sources, applies all patches and builds quiche in one go.
 If a patch fails to apply check the logs under `libs/logs` for details.
 

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -233,6 +233,11 @@ fetch_quiche() {
             if git clone --depth 1 "$MIRROR_URL" "$PATCHED_DIR" >"$log_file" 2>&1; then
                 git -C "$PATCHED_DIR" submodule update --init --recursive >>"$log_file" 2>&1
                 ensure_quiche_dir
+                if [ ! -d "$PATCHED_DIR/quiche" ]; then
+                    warn "Quiche-Verzeichnis fehlt nach dem Klonen"
+                    rm -rf "$PATCHED_DIR"
+                    continue
+                fi
                 break
             fi
             warn "Klonen fehlgeschlagen. Details siehe $log_file"
@@ -256,6 +261,10 @@ fetch_quiche() {
 apply_patches() {
     log "Starte Anwenden der Patches..."
     check_dependencies git patch
+
+    if [ ! -d "$PATCHED_DIR/quiche" ]; then
+        error "Quiche-Quellcode fehlt. Bitte zuerst $0 --step fetch ausführen"
+    fi
     
     if [ ! -d "$PATCHES_DIR" ] || [ -z "$(ls -A "$PATCHES_DIR"/*.patch 2>/dev/null)" ]; then
         warn "Keine Patch-Dateien in $PATCHES_DIR gefunden"


### PR DESCRIPTION
## Summary
- improve clone step in `quiche_workflow.sh`
- ensure patches fail early when quiche sources are missing
- document `QUICHE_PATH` environment variable in `Quiche_Dependency.md`

## Testing
- `cargo check` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686cda5a893083338a80c69891a03fb8