### PR TITLE
Expose ClientHello builder and improve fingerprint loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Quick start after cloning:
 cargo build --release
 ```
 
+Browser fingerprints are stored as base64 encoded `.chlo` files under
+`browser_profiles/`. When the patched quiche is built, these files are
+fed into the new `ChloBuilder` API to recreate the exact ClientHello
+layout during connection setup.
+
 If the command fails with a missing commit error (e.g.
 ```
 fatal: remote error: upload-pack: not our ref 5700a7c74927d2c4912ac95e904c6ad3642b6868

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -114,8 +114,9 @@ selector.encrypt(plaintext, len, key, nonce, ad, ad_len, ciphertext, tag);
 3. **MORUS-1280-128**: Software fallback without hardware acceleration
 
 The selected cipher's IANA ID can be retrieved via `CipherSuiteSelector::tls_cipher()`.
-`StealthManager` uses this to build a matching TLS ClientHello with
-`quiche_config_set_custom_tls`, ensuring end-to-end compatibility.
+`StealthManager` uses this to build a matching TLS ClientHello via the
+`ChloBuilder` API (`quiche_chlo_builder_*`), ensuring end-to-end
+compatibility.
 
 #### Forward Error Correction (FEC) Module
 Defined in `fec.rs`:

--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -144,7 +144,7 @@ without modifying the Rust code of quiche during runtime.
 ### Required Changes
 
 - `libs/patched_quiche/quiche/include/quiche.h` – declaration of the additional
-  `quiche_config_set_custom_tls()` function.
+  `quiche_config_set_custom_tls()` and builder helpers.
 - `libs/patched_quiche/quiche/src/ffi.rs` – implementation of the FFI symbol and
   binding to `Config`.
 - `libs/patched_quiche/quiche/src/lib.rs` – store the provided ClientHello in the
@@ -161,6 +161,13 @@ modifications (see `custom_tls.patch`). Apply them via
 ```c
 void quiche_config_set_custom_tls(quiche_config *cfg,
                                   const uint8_t *hello, size_t len);
+typedef struct quiche_chlo_builder quiche_chlo_builder;
+quiche_chlo_builder *quiche_chlo_builder_new();
+void quiche_chlo_builder_add(quiche_chlo_builder *b,
+                             const uint8_t *data, size_t len);
+void quiche_config_set_chlo_builder(quiche_config *cfg,
+                                    quiche_chlo_builder *b);
+void quiche_chlo_builder_free(quiche_chlo_builder *b);
 ```
 
 When the patched library is absent, a stub implementation lives in
@@ -169,8 +176,8 @@ When the patched library is absent, a stub implementation lives in
 ## Browser Fingerprints
 
 Real ClientHello messages are stored as base64 files in `browser_profiles/*.chlo`.
-`StealthManager` loads the corresponding file and injects the bytes via
-`quiche_config_set_custom_tls`.
+`StealthManager` loads the corresponding file and injects the bytes using
+`quiche_chlo_builder_*` helpers.
 
 ### Neue Fingerprints erstellen
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,7 +51,8 @@ Use the `--config` flag to load a unified TOML file containing FEC, stealth and 
 When built against the patched `quiche` library, QuicFuscate can replay
 captured TLS ClientHello messages. Store the base64 encoded handshake in
 `browser_profiles/<browser>_<os>.chlo` and build with `QUICHE_PATH` pointing
-to the patched sources:
+to the patched sources. The runtime loads the file, feeds the bytes to
+`ChloBuilder` and attaches it to the configuration:
 
 ```bash
 export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche

--- a/libs/patches/boringssl_clienthello_hook.patch
+++ b/libs/patches/boringssl_clienthello_hook.patch
@@ -1,3 +1,4 @@
+diff --git a/deps/boringssl/ssl/handshake_client.cc b/deps/boringssl/ssl/handshake_client.cc
 --- a/deps/boringssl/ssl/handshake_client.cc
 +++ b/deps/boringssl/ssl/handshake_client.cc
 @@

--- a/libs/patches/boringssl_deterministic_grease.patch
+++ b/libs/patches/boringssl_deterministic_grease.patch
@@ -1,0 +1,56 @@
+diff --git a/deps/boringssl/include/openssl/ssl.h b/deps/boringssl/include/openssl/ssl.h
+--- a/deps/boringssl/include/openssl/ssl.h
++++ b/deps/boringssl/include/openssl/ssl.h
+@@
+ void SSL_set_custom_client_hello(SSL *ssl, const uint8_t *data, size_t len);
++// Disable GREASE and other randomization for deterministic handshakes.
++void SSL_disable_tls_grease(SSL *ssl, int disabled);
++void SSL_set_deterministic_hello(SSL *ssl, int enabled);
+diff --git a/deps/boringssl/ssl/internal.h b/deps/boringssl/ssl/internal.h
+--- a/deps/boringssl/ssl/internal.h
++++ b/deps/boringssl/ssl/internal.h
+@@
+   std::vector<uint8_t> custom_client_hello;
++  bool disable_tls_grease = false;
++  bool deterministic_hello = false;
+ };
+diff --git a/deps/boringssl/ssl/ssl_lib.cc b/deps/boringssl/ssl/ssl_lib.cc
+--- a/deps/boringssl/ssl/ssl_lib.cc
++++ b/deps/boringssl/ssl/ssl_lib.cc
+@@
+ void SSL_set_custom_client_hello(SSL *ssl, const uint8_t *data, size_t len) {
+     ssl->custom_client_hello.assign(data, data + len);
+ }
++
++void SSL_disable_tls_grease(SSL *ssl, int disabled) {
++    ssl->disable_tls_grease = disabled != 0;
++}
++
++void SSL_set_deterministic_hello(SSL *ssl, int enabled) {
++    ssl->deterministic_hello = enabled != 0;
++}
+diff --git a/deps/boringssl/ssl/handshake_client.cc b/deps/boringssl/ssl/handshake_client.cc
+--- a/deps/boringssl/ssl/handshake_client.cc
++++ b/deps/boringssl/ssl/handshake_client.cc
+@@
+   SSL *const ssl = hs->ssl;
++  if (!ssl->custom_client_hello.empty()) {
++    Array<uint8_t> msg;
++    if (!msg.CopyFrom(bssl::Span<const uint8_t>(
++            ssl->custom_client_hello.data(),
++            ssl->custom_client_hello.size()))) {
++      return false;
++    }
++    return ssl->method->add_message(ssl, std::move(msg));
++  }
++  if (ssl->disable_tls_grease) {
++    hs->should_grease = false;
++  }
++  if (ssl->deterministic_hello) {
++    hs->deterministic = true;
++  }
+   ScopedCBB cbb;
+   CBB body;
+   ssl_client_hello_type_t type = hs->selected_ech_config
+                                      ? ssl_client_hello_outer
+                                      : ssl_client_hello_unencrypted;

--- a/libs/patches/custom_tls_builder.patch
+++ b/libs/patches/custom_tls_builder.patch
@@ -1,0 +1,71 @@
+diff -ruN '--exclude=.git' quiche_vanilla/include/quiche.h quiche_patch/include/quiche.h
+@@
+ void quiche_config_set_custom_tls(quiche_config *cfg,
+                                   const uint8_t *hello, size_t len);
++typedef struct quiche_chlo_builder quiche_chlo_builder;
++quiche_chlo_builder *quiche_chlo_builder_new();
++void quiche_chlo_builder_add(quiche_chlo_builder *b, const uint8_t *data, size_t len);
++void quiche_config_set_chlo_builder(quiche_config *cfg, quiche_chlo_builder *b);
++void quiche_chlo_builder_free(quiche_chlo_builder *b);
+ diff -ruN '--exclude=.git' quiche_vanilla/src/ffi.rs quiche_patch/src/ffi.rs
+@@
+ pub extern "C" fn quiche_config_set_custom_tls(
+     config: &mut Config, hello: *const u8, len: size_t,
+ ) {
+     let hello = unsafe { slice::from_raw_parts(hello, len) };
+     config.set_custom_tls(hello);
+ }
++
++#[no_mangle]
++pub extern "C" fn quiche_chlo_builder_new() -> *mut crate::ChloBuilder {
++    Box::into_raw(Box::new(crate::ChloBuilder::new()))
++}
++
++#[no_mangle]
++pub extern "C" fn quiche_chlo_builder_add(
++    builder: &mut crate::ChloBuilder, data: *const u8, len: size_t,
++) {
++    let slice = unsafe { slice::from_raw_parts(data, len) };
++    builder.add(slice);
++}
++
++#[no_mangle]
++pub extern "C" fn quiche_config_set_chlo_builder(
++    cfg: &mut Config, builder: *mut crate::ChloBuilder,
++) {
++    if let Some(b) = unsafe { builder.as_ref() } {
++        cfg.set_custom_tls(b.bytes());
++    }
++}
++
++#[no_mangle]
++pub extern "C" fn quiche_chlo_builder_free(builder: *mut crate::ChloBuilder) {
++    if !builder.is_null() {
++        unsafe { drop(Box::from_raw(builder)); }
++    }
++}
+ diff -ruN '--exclude=.git' quiche_vanilla/src/lib.rs quiche_patch/src/lib.rs
+@@
+ pub struct Config {
+@@
+     custom_tls: Option<Vec<u8>>,
+@@
+ }
+@@
+     pub fn set_custom_tls(&mut self, hello: &[u8]) {
+         self.custom_tls = Some(hello.to_vec());
+     }
++
++    pub fn set_custom_tls_builder(&mut self, builder: &ChloBuilder) {
++        self.custom_tls = Some(builder.bytes().to_vec());
++    }
+@@
+ }
++
++pub struct ChloBuilder(Vec<u8>);
++
++impl ChloBuilder {
++    pub fn new() -> Self { Self(Vec::new()) }
++    pub fn add(&mut self, data: &[u8]) { self.0.extend_from_slice(data); }
++    pub fn bytes(&self) -> &[u8] { &self.0 }
++}

--- a/libs/patches/series
+++ b/libs/patches/series
@@ -1,5 +1,7 @@
 boringssl_custom_hello.patch
 boringssl_clienthello_hook.patch
+boringssl_deterministic_grease.patch
 custom_tls.patch
+custom_tls_builder.patch
 simd_optimizations.patch
 readme_quicfuscate.patch

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -1109,11 +1109,15 @@ impl StealthManager {
 
             if let Some(ref hello) = fingerprint.client_hello {
                 unsafe {
-                    tls_ffi::quiche_config_set_custom_tls(
-                        config as *mut _ as *mut std::ffi::c_void,
-                        hello.as_ptr(),
-                        hello.len(),
-                    );
+                    let b = tls_ffi::quiche_chlo_builder_new_wrapper();
+                    if !b.is_null() {
+                        tls_ffi::quiche_chlo_builder_add_wrapper(b, hello.as_ptr(), hello.len());
+                        tls_ffi::quiche_config_set_chlo_builder_wrapper(
+                            config as *mut _ as *mut std::ffi::c_void,
+                            b,
+                        );
+                        tls_ffi::quiche_chlo_builder_free_wrapper(b);
+                    }
                 }
             } else {
                 error!(
@@ -1152,11 +1156,12 @@ impl StealthManager {
 
         if let (Some(ref hello), Some(c)) = (&p.client_hello, cfg.as_deref_mut()) {
             unsafe {
-                tls_ffi::quiche_config_set_custom_tls(
-                    c as *mut _ as *mut std::ffi::c_void,
-                    hello.as_ptr(),
-                    hello.len(),
-                );
+                let b = tls_ffi::quiche_chlo_builder_new_wrapper();
+                if !b.is_null() {
+                    tls_ffi::quiche_chlo_builder_add_wrapper(b, hello.as_ptr(), hello.len());
+                    tls_ffi::quiche_config_set_chlo_builder_wrapper(c as *mut _ as *mut std::ffi::c_void, b);
+                    tls_ffi::quiche_chlo_builder_free_wrapper(b);
+                }
             }
         }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -147,13 +147,15 @@ async fn tls_custom_clienthello() {
     let custom_hello = [1u8, 2, 3, 4, 5];
     unsafe {
         extern "C" {
-            fn quiche_config_set_custom_tls(cfg: *mut c_void, hello: *const u8, len: usize);
+            fn quiche_chlo_builder_new_wrapper() -> *mut c_void;
+            fn quiche_chlo_builder_add_wrapper(b: *mut c_void, data: *const u8, len: usize);
+            fn quiche_config_set_chlo_builder_wrapper(cfg: *mut c_void, b: *mut c_void);
+            fn quiche_chlo_builder_free_wrapper(b: *mut c_void);
         }
-        quiche_config_set_custom_tls(
-            &mut client_config as *mut _ as *mut c_void,
-            custom_hello.as_ptr(),
-            custom_hello.len(),
-        );
+        let b = quiche_chlo_builder_new_wrapper();
+        quiche_chlo_builder_add_wrapper(b, custom_hello.as_ptr(), custom_hello.len());
+        quiche_config_set_chlo_builder_wrapper(&mut client_config as *mut _ as *mut c_void, b);
+        quiche_chlo_builder_free_wrapper(b);
     }
 
     let stealth_cfg = StealthConfig::default();

--- a/tests/tls_ffi.rs
+++ b/tests/tls_ffi.rs
@@ -1,10 +1,19 @@
-use quicfuscate::tls_ffi::{quiche_config_set_custom_tls, LAST_HELLO};
+use quicfuscate::tls_ffi::{
+    quiche_chlo_builder_add_wrapper, quiche_chlo_builder_free_wrapper,
+    quiche_chlo_builder_new_wrapper, quiche_config_set_chlo_builder_wrapper,
+    LAST_HELLO,
+};
 use std::os::raw::c_void;
 
 #[test]
 fn ffi_records_clienthello_bytes() {
     let data = [0u8, 1, 2, 3];
-    unsafe { quiche_config_set_custom_tls(std::ptr::null_mut::<c_void>(), data.as_ptr(), data.len()); }
+    unsafe {
+        let b = quiche_chlo_builder_new_wrapper();
+        quiche_chlo_builder_add_wrapper(b, data.as_ptr(), data.len());
+        quiche_config_set_chlo_builder_wrapper(std::ptr::null_mut::<c_void>(), b);
+        quiche_chlo_builder_free_wrapper(b);
+    }
     let stored = LAST_HELLO.lock().unwrap().clone();
     assert_eq!(stored, data);
 }


### PR DESCRIPTION
## Summary
- add BoringSSL patches for deterministic handshakes
- extend quiche patches with a ClientHello builder API
- integrate builder usage in `StealthManager`
- update documentation about `.chlo` files and new API

## Testing
- `cargo test --quiet` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686d3b10d9e883339e35426d64d9bc68