### PR TITLE
Add custom TLS injection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,7 @@ Quick start after cloning:
 ./scripts/quiche_workflow.sh --step fetch
 cargo build --release
 ```
-
-Browser fingerprints are stored as base64 encoded `.chlo` files under
-`browser_profiles/`. When the patched quiche is built, these files are
-fed into the new `ChloBuilder` API to recreate the exact ClientHello
-layout during connection setup.
+Browser fingerprints are stored as base64 encoded `.chlo` files under `browser_profiles/`. When the patched quiche is built, these files are injected via `quiche_config_set_custom_tls` to recreate the exact ClientHello layout during connection setup. Select the desired fingerprint via `--profile` and `--os` at runtime.
 
 If the command fails with a missing commit error (e.g.
 ```

--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -115,8 +115,7 @@ selector.encrypt(plaintext, len, key, nonce, ad, ad_len, ciphertext, tag);
 
 The selected cipher's IANA ID can be retrieved via `CipherSuiteSelector::tls_cipher()`.
 `StealthManager` uses this to build a matching TLS ClientHello via the
-`ChloBuilder` API (`quiche_chlo_builder_*`), ensuring end-to-end
-compatibility.
+`quiche_config_set_custom_tls` API, ensuring end-to-end compatibility.
 
 #### Forward Error Correction (FEC) Module
 Defined in `fec.rs`:

--- a/docs/Quiche_Dependency.md
+++ b/docs/Quiche_Dependency.md
@@ -143,8 +143,7 @@ without modifying the Rust code of quiche during runtime.
 
 ### Required Changes
 
-- `libs/patched_quiche/quiche/include/quiche.h` – declaration of the additional
-  `quiche_config_set_custom_tls()` and builder helpers.
+- `libs/patched_quiche/quiche/include/quiche.h` – declaration of the additional `quiche_config_set_custom_tls()` API.
 - `libs/patched_quiche/quiche/src/ffi.rs` – implementation of the FFI symbol and
   binding to `Config`.
 - `libs/patched_quiche/quiche/src/lib.rs` – store the provided ClientHello in the
@@ -161,15 +160,7 @@ modifications (see `custom_tls.patch`). Apply them via
 ```c
 void quiche_config_set_custom_tls(quiche_config *cfg,
                                   const uint8_t *hello, size_t len);
-typedef struct quiche_chlo_builder quiche_chlo_builder;
-quiche_chlo_builder *quiche_chlo_builder_new();
-void quiche_chlo_builder_add(quiche_chlo_builder *b,
-                             const uint8_t *data, size_t len);
-void quiche_config_set_chlo_builder(quiche_config *cfg,
-                                    quiche_chlo_builder *b);
-void quiche_chlo_builder_free(quiche_chlo_builder *b);
 ```
-
 When the patched library is absent, a stub implementation lives in
 `src/tls_ffi.rs` so unit tests continue to compile.
 
@@ -177,7 +168,7 @@ When the patched library is absent, a stub implementation lives in
 
 Real ClientHello messages are stored as base64 files in `browser_profiles/*.chlo`.
 `StealthManager` loads the corresponding file and injects the bytes using
-`quiche_chlo_builder_*` helpers.
+`quiche_config_set_custom_tls` helper function.
 
 ### Neue Fingerprints erstellen
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -47,12 +47,11 @@ Use the `--config` flag to load a unified TOML file containing FEC, stealth and 
 ```
 
 ### Real TLS Fingerprints
-
 When built against the patched `quiche` library, QuicFuscate can replay
 captured TLS ClientHello messages. Store the base64 encoded handshake in
 `browser_profiles/<browser>_<os>.chlo` and build with `QUICHE_PATH` pointing
-to the patched sources. The runtime loads the file, feeds the bytes to
-`ChloBuilder` and attaches it to the configuration:
+to the patched sources. The runtime loads the file and injects the bytes
+through `quiche_config_set_custom_tls`:
 
 ```bash
 export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche

--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -291,7 +291,7 @@ apply_patches() {
         patch_count=$((patch_count + 1))
         log "Wende Patch an: $name"
         local patch_log="$LOG_DIR/patch_${name}_$(date +%Y%m%d_%H%M%S).log"
-        if [[ "$name" == "custom_tls.patch" ]]; then
+        if [[ "$name" == "custom_tls.patch" || "$name" == boringssl_*.patch ]]; then
             if ! (cd "$PATCHED_DIR/quiche" && patch -p1 --no-backup-if-mismatch -r - < "$patch_file" >"$patch_log" 2>&1); then
                 patch_failure "Fehler beim Anwenden von $name" "$backup_dir" "$patch_log"
             fi
@@ -338,7 +338,7 @@ verify_patches() {
         if [ -f "$patch_file" ]; then
             local name="$(basename \"$patch_file\")"
             log "Prüfe Patch: $name"
-            if [[ "$name" == "custom_tls.patch" ]]; then
+            if [[ "$name" == "custom_tls.patch" || "$name" == boringssl_*.patch ]]; then
                 (cd "$PATCHED_DIR/quiche" && patch --dry-run -p1 < "$patch_file" >/dev/null) || error "Patch $name konnte nicht verifiziert werden"
             else
                 patch --dry-run -p1 < "$patch_file" >/dev/null || error "Patch $name konnte nicht verifiziert werden"

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -835,41 +835,9 @@ impl TlsClientHelloSpoofer {
     }
 
     fn load_client_hello(browser: BrowserProfile, os: OsProfile) -> Option<Vec<u8>> {
-        let data = match (browser, os) {
-            (BrowserProfile::Chrome, OsProfile::Windows) => {
-                Some(include_str!("../browser_profiles/chrome_windows.chlo"))
-            }
-            (BrowserProfile::Firefox, OsProfile::Windows) => {
-                Some(include_str!("../browser_profiles/firefox_windows.chlo"))
-            }
-            (BrowserProfile::Opera, OsProfile::Windows) => {
-                Some(include_str!("../browser_profiles/opera_windows.chlo"))
-            }
-            (BrowserProfile::Brave, OsProfile::Windows) => {
-                Some(include_str!("../browser_profiles/brave_windows.chlo"))
-            }
-            (BrowserProfile::Edge, OsProfile::Windows) => {
-                Some(include_str!("../browser_profiles/edge_windows.chlo"))
-            }
-            (BrowserProfile::Vivaldi, OsProfile::Windows) => {
-                Some(include_str!("../browser_profiles/vivaldi_windows.chlo"))
-            }
-            (BrowserProfile::Safari, OsProfile::MacOS) => {
-                Some(include_str!("../browser_profiles/safari_macos.chlo"))
-            }
-            _ => None,
-        };
-
-        if let Some(s) = data {
-            base64::decode(s.trim()).ok()
-        } else {
-            let path = Self::profile_path(browser, os);
-            std::fs::read_to_string(&path)
-                .ok()
-                .and_then(|d| base64::decode(d.trim()).ok())
-        }
+        let path = Self::profile_path(browser, os);
+        std::fs::read_to_string(&path).ok().and_then(|d| base64::decode(d.trim()).ok())
     }
-
     /// Returns a list of all available browser/OS combinations for which a
     /// ClientHello dump exists in `browser_profiles`.
     pub fn available_profiles() -> Vec<(BrowserProfile, OsProfile)> {
@@ -1109,15 +1077,7 @@ impl StealthManager {
 
             if let Some(ref hello) = fingerprint.client_hello {
                 unsafe {
-                    let b = tls_ffi::quiche_chlo_builder_new_wrapper();
-                    if !b.is_null() {
-                        tls_ffi::quiche_chlo_builder_add_wrapper(b, hello.as_ptr(), hello.len());
-                        tls_ffi::quiche_config_set_chlo_builder_wrapper(
-                            config as *mut _ as *mut std::ffi::c_void,
-                            b,
-                        );
-                        tls_ffi::quiche_chlo_builder_free_wrapper(b);
-                    }
+                    tls_ffi::quiche_config_set_custom_tls(config as *mut _ as *mut std::ffi::c_void, hello.as_ptr(), hello.len());
                 }
             } else {
                 error!(
@@ -1156,12 +1116,7 @@ impl StealthManager {
 
         if let (Some(ref hello), Some(c)) = (&p.client_hello, cfg.as_deref_mut()) {
             unsafe {
-                let b = tls_ffi::quiche_chlo_builder_new_wrapper();
-                if !b.is_null() {
-                    tls_ffi::quiche_chlo_builder_add_wrapper(b, hello.as_ptr(), hello.len());
-                    tls_ffi::quiche_config_set_chlo_builder_wrapper(c as *mut _ as *mut std::ffi::c_void, b);
-                    tls_ffi::quiche_chlo_builder_free_wrapper(b);
-                }
+                tls_ffi::quiche_config_set_custom_tls(c as *mut _ as *mut std::ffi::c_void, hello.as_ptr(), hello.len());
             }
         }
 


### PR DESCRIPTION
## Summary
- apply custom tls injection API
- load `.chlo` clienthellos from runtime
- patch workflow script for boringssl patches
- document new profile usage

## Testing
- `cargo test` *(fails: cannot compile dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d45382c1c833383ae0cbdd889fb7a