### PR TITLE
Improve FakeTLS handshake

### DIFF
--- a/docs/DOCUMENTATION.md
+++ b/docs/DOCUMENTATION.md
@@ -476,6 +476,13 @@ fingerprint:
 5. Launch QuicFuscate with `--profile <browser> --os <os>` to activate
    the new fingerprint at runtime.
 
+### FakeTLS Handshake
+
+FakeTLS emits a forged TLS handshake without performing real encryption.
+The ClientHello is taken from the active fingerprint profile and the server
+responds with a minimal ServerHello and certificate. This keeps the
+handshake lightweight while still mimicking genuine TLS traffic.
+
 ### HTTP Header Spoofing
 Defined in `stealth/browser_profiles/headers/FakeHeaders.rs`:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -62,6 +62,14 @@ export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche
 The runtime automatically loads the matching profile based on the selected
 `--profile` and `--os` options.
 
+### FakeTLS Handshake
+
+When stealth mode is active, QuicFuscate sends a minimal TLS handshake.
+The ClientHello bytes are taken from the selected fingerprint profile and
+a synthetic ServerHello with placeholder certificate is returned. This
+reduces handshake overhead while still presenting TLS-like packets on the
+wire.
+
 ### Optimization Parameters
 
 Both client and server accept additional flags to tune the memory pool used for

--- a/src/core.rs
+++ b/src/core.rs
@@ -106,7 +106,7 @@ impl QuicFuscateConnection {
             optimization_manager.clone(),
         ));
 
-        if stealth_manager.current_profile().handshake_type == crate::stealth::HandshakeType::FakeTLS {
+        if stealth_manager.use_fake_tls() {
             let _ = stealth_manager.fake_tls_handshake();
         } else if use_utls {
             stealth_manager

--- a/src/fake_tls.rs
+++ b/src/fake_tls.rs
@@ -6,13 +6,22 @@ use crate::stealth::FingerprintProfile;
 
 /// Hard coded ClientHello payload used when a profile does not provide one.
 /// This is not a valid TLS handshake, it merely resembles one for DPI evasion.
-pub const DEFAULT_CLIENT_HELLO: &[u8] = b"\x16\x03\x01\x00\x10fake-client";
+pub const DEFAULT_CLIENT_HELLO: &[u8] = &[
+    0x16, 0x03, 0x01, 0x00, 0x0f, // record header
+    0x01, 0x00, 0x00, 0x0b, // handshake header
+    b'f', b'a', b'k', b'e', b'-', b'c', b'l', b'i', b'e', b'n', b't',
+];
 
 /// Hard coded ServerHello payload returned by the fake server.
-pub const DEFAULT_SERVER_HELLO: &[u8] = b"\x16\x03\x03\x00\x0ffake-server";
+pub const DEFAULT_SERVER_HELLO: &[u8] = &[
+    0x16, 0x03, 0x03, 0x00, 0x0f, 0x02, 0x00, 0x00, 0x0b, b'f', b'a', b'k', b'e', b'-', b's', b'e',
+    b'r', b'v', b'e', b'r',
+];
 
 /// Hard coded certificate payload used by the fake server.
-pub const DEFAULT_CERTIFICATE: &[u8] = b"\x16\x03\x03\x00\x04cert";
+pub const DEFAULT_CERTIFICATE: &[u8] = &[
+    0x16, 0x03, 0x03, 0x00, 0x08, 0x0b, 0x00, 0x00, 0x04, b'c', b'e', b'r', b't',
+];
 
 pub struct FakeTls;
 
@@ -26,10 +35,26 @@ impl FakeTls {
         }
     }
 
+    /// Helper to build a TLS handshake record for the given handshake type and
+    /// payload.
+    fn record(htype: u8, payload: &[u8]) -> Vec<u8> {
+        let mut out = Vec::with_capacity(payload.len() + 9);
+        out.extend_from_slice(&[0x16, 0x03, 0x03]); // Handshake record, TLS 1.2
+        let len = payload.len() + 4;
+        out.extend_from_slice(&(len as u16).to_be_bytes());
+        out.push(htype);
+        let l = (payload.len() as u32).to_be_bytes();
+        out.extend_from_slice(&l[1..]);
+        out.extend_from_slice(payload);
+        out
+    }
+
     /// Returns the fake server response consisting of ServerHello and
     /// Certificate records.
     pub fn server_response() -> Vec<u8> {
-        [DEFAULT_SERVER_HELLO, DEFAULT_CERTIFICATE].concat()
+        let mut out = Self::record(0x02, b"fake-server");
+        out.extend_from_slice(&Self::record(0x0b, b"cert"));
+        out
     }
 
     /// Generates the complete FakeTLS handshake sequence.
@@ -39,4 +64,3 @@ impl FakeTls {
         out
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,9 +110,6 @@ enum Commands {
         /// Show TLS debug information
         #[clap(long)]
         debug_tls: bool,
-        /// Use FakeTLS instead of a real handshake
-        #[clap(long)]
-        fake_tls: bool,
         /// List available browser fingerprints
         #[clap(long)]
         list_fingerprints: bool,
@@ -135,9 +132,6 @@ enum Commands {
         /// Disable HTTP/3 masquerading
         #[clap(long)]
         disable_http3: bool,
-        /// Use FakeTLS instead of a real handshake
-        #[clap(long)]
-        fake_tls: bool,
     },
     /// Runs the server
     Server {
@@ -278,7 +272,6 @@ async fn main() -> std::io::Result<()> {
                 *disable_fronting,
                 *disable_xor,
                 *disable_http3,
-                *fake_tls,
             )
             .await?;
         }
@@ -300,7 +293,6 @@ async fn main() -> std::io::Result<()> {
             disable_fronting,
             disable_xor,
             disable_http3,
-            fake_tls,
         } => {
             let browser = *profile;
             let os_profile = *os;
@@ -325,7 +317,6 @@ async fn main() -> std::io::Result<()> {
                 *disable_fronting,
                 *disable_xor,
                 *disable_http3,
-                *fake_tls,
             )
             .await?;
         }
@@ -396,7 +387,6 @@ async fn run_client(
     disable_fronting: bool,
     disable_xor: bool,
     disable_http3: bool,
-    fake_tls: bool,
 ) -> std::io::Result<()> {
     let config_path = config.clone();
     if list_fingerprints {
@@ -506,7 +496,6 @@ async fn run_client(
     let mut stealth_config = stealth_config;
     stealth_config.browser_profile = profile;
     stealth_config.os_profile = os;
-    stealth_config.use_fake_tls = fake_tls;
     stealth_config.enable_doh = !disable_doh;
     stealth_config.doh_provider = doh_provider.to_string();
     stealth_config.enable_domain_fronting = !disable_fronting;
@@ -693,7 +682,6 @@ async fn run_server(
     disable_fronting: bool,
     disable_xor: bool,
     disable_http3: bool,
-    fake_tls: bool,
 ) -> std::io::Result<()> {
     let config_path = config.clone();
     let socket = std::net::UdpSocket::bind(listen_addr)?;
@@ -779,7 +767,6 @@ async fn run_server(
         let mut sc = stealth_config.lock().unwrap();
         sc.browser_profile = profile;
         sc.os_profile = os;
-        sc.use_fake_tls = fake_tls;
         sc.enable_doh = !disable_doh;
         sc.doh_provider = doh_provider.to_string();
         sc.enable_domain_fronting = !disable_fronting;

--- a/tests/fake_tls.rs
+++ b/tests/fake_tls.rs
@@ -1,10 +1,11 @@
-use quicfuscate::fake_tls::{FakeTls, DEFAULT_CLIENT_HELLO, DEFAULT_SERVER_HELLO, DEFAULT_CERTIFICATE};
-use quicfuscate::stealth::{BrowserProfile, FingerprintProfile, OsProfile, HandshakeType};
+use quicfuscate::fake_tls::{
+    FakeTls, DEFAULT_CERTIFICATE, DEFAULT_CLIENT_HELLO, DEFAULT_SERVER_HELLO,
+};
+use quicfuscate::stealth::{BrowserProfile, FingerprintProfile, OsProfile};
 
 #[test]
 fn fake_tls_handshake_sequence() {
     let mut fp = FingerprintProfile::new(BrowserProfile::Chrome, OsProfile::Windows);
-    fp.handshake_type = HandshakeType::FakeTLS;
     fp.client_hello = None; // ensure default is used
     let hello = FakeTls::client_hello(&fp);
     assert_eq!(hello, DEFAULT_CLIENT_HELLO);


### PR DESCRIPTION
## Summary
- use profile ClientHello for FakeTLS
- build minimal TLS records for server response
- always enable FakeTLS in `StealthManager`
- drop `HandshakeType` enum and CLI flag
- document FakeTLS handshake

## Testing
- `cargo test --quiet` *(fails: Quiche workflow missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d77e3c61883339dc07f73b4501e27