### PR TITLE
Implement real TLS fingerprint hooks

### DIFF
--- a/scripts/quiche_workflow.sh
+++ b/scripts/quiche_workflow.sh
@@ -291,7 +291,7 @@ apply_patches() {
         patch_count=$((patch_count + 1))
         log "Wende Patch an: $name"
         local patch_log="$LOG_DIR/patch_${name}_$(date +%Y%m%d_%H%M%S).log"
-        if [[ "$name" == "custom_tls.patch" ]]; then
+        if [[ "$name" == "custom_tls.patch" || "$name" == "custom_tls_builder.patch" || $name == boringssl_* ]]; then
             if ! (cd "$PATCHED_DIR/quiche" && patch -p1 --no-backup-if-mismatch -r - < "$patch_file" >"$patch_log" 2>&1); then
                 patch_failure "Fehler beim Anwenden von $name" "$backup_dir" "$patch_log"
             fi
@@ -309,6 +309,8 @@ apply_patches() {
         fi
         # Rebuild BoringSSL hooks to ensure patched symbols are available
         run_command "BoringSSL hooks build" "(cd \"$PATCHED_DIR\" && cargo build --release -p quiche --features ffi --lib)"
+        # Compile the full library after patching
+        build_quiche
     else
         warn "Keine Patch-Dateien im .patch-Format gefunden"
     fi

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -1076,7 +1076,6 @@ impl StealthManager {
         crypto_manager: Arc<CryptoManager>,
         optimization_manager: Arc<OptimizationManager>,
     ) -> Self {
-        config.use_fake_tls = true;
         let mut fingerprint = FingerprintProfile::new(config.browser_profile, config.os_profile);
         if fingerprint.client_hello.is_none() {
             fingerprint.client_hello =


### PR DESCRIPTION
## Summary
- add BoringSSL control hooks to `tls_ffi`
- stop forcing FakeTLS in `StealthManager`
- patch workflow applies quiche patches inside submodule and rebuilds

## Testing
- `cargo test` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686d7efb55ec833391bda00291f00ea3