### PR TITLE
Add configurable FakeTLS support

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -70,6 +70,30 @@ a synthetic ServerHello with placeholder certificate is returned. This
 reduces handshake overhead while still presenting TLS-like packets on the
 wire.
 
+To force FakeTLS via the configuration file add:
+
+```toml
+[stealth]
+use_fake_tls = true
+```
+
+Custom handshakes can be generated programmatically:
+
+```rust
+use quicfuscate::fake_tls::{FakeTls, ClientHelloParams, ServerHelloParams};
+
+let hello = FakeTls::client_hello_custom(ClientHelloParams {
+    tls_version: 0x0303,
+    cipher_suites: &[0x1301, 0x1302],
+    extensions: &[],
+});
+let server = FakeTls::server_hello_custom(ServerHelloParams {
+    tls_version: 0x0303,
+    cipher_suite: 0x1301,
+    extensions: &[],
+});
+```
+
 ### Optimization Parameters
 
 Both client and server accept additional flags to tune the memory pool used for

--- a/src/core.rs
+++ b/src/core.rs
@@ -106,12 +106,11 @@ impl QuicFuscateConnection {
             optimization_manager.clone(),
         ));
 
-        if stealth_manager.use_fake_tls() {
-            let _ = stealth_manager.fake_tls_handshake();
-        } else if use_utls {
-            stealth_manager
-                .apply_utls_profile(&mut config, Some(CipherSuiteSelector::new().tls_cipher()));
-        }
+        let _ = stealth_manager.configure_tls(
+            &mut config,
+            use_utls,
+            Some(CipherSuiteSelector::new().tls_cipher()),
+        );
 
         let scid = quiche::ConnectionId::from_ref(&[0; quiche::MAX_CONN_ID_LEN]);
 

--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -1235,6 +1235,26 @@ impl StealthManager {
         fake_tls::FakeTls::handshake(&fp)
     }
 
+    /// Configures the provided quiche `Config` for the active fingerprint.
+    /// Depending on the configuration this either applies an uTLS profile or
+    /// generates FakeTLS handshake bytes. The returned vector is only populated
+    /// when FakeTLS is in use.
+    pub fn configure_tls(
+        &self,
+        cfg: &mut quiche::Config,
+        enable_utls: bool,
+        preferred: Option<u16>,
+    ) -> Option<Vec<u8>> {
+        if self.config.use_fake_tls {
+            Some(self.fake_tls_handshake())
+        } else if enable_utls {
+            self.apply_utls_profile(cfg, preferred);
+            None
+        } else {
+            None
+        }
+    }
+
     /// Starts automatic rotation through the given browser profiles.
     /// This spawns a task on the DoH runtime which periodically updates the
     /// active fingerprint.

--- a/tests/fake_tls.rs
+++ b/tests/fake_tls.rs
@@ -1,5 +1,6 @@
 use quicfuscate::fake_tls::{
-    FakeTls, DEFAULT_CERTIFICATE, DEFAULT_CLIENT_HELLO, DEFAULT_SERVER_HELLO,
+    ClientHelloParams, FakeTls, ServerHelloParams, DEFAULT_CERTIFICATE, DEFAULT_CLIENT_HELLO,
+    DEFAULT_SERVER_HELLO,
 };
 use quicfuscate::stealth::{BrowserProfile, FingerprintProfile, OsProfile};
 
@@ -17,4 +18,22 @@ fn fake_tls_handshake_sequence() {
     let mut expected = DEFAULT_CLIENT_HELLO.to_vec();
     expected.extend_from_slice(&resp);
     assert_eq!(all, expected);
+}
+
+#[test]
+fn custom_handshake_builder() {
+    let ch = ClientHelloParams {
+        tls_version: 0x0303,
+        cipher_suites: &[0x1301, 0x1302],
+        extensions: &[],
+    };
+    let sh = ServerHelloParams {
+        tls_version: 0x0303,
+        cipher_suite: 0x1301,
+        extensions: &[],
+    };
+
+    let hello = FakeTls::client_hello_custom(ch);
+    let server = FakeTls::server_hello_custom(sh);
+    assert_eq!(FakeTls::handshake_custom(ch, sh), [hello, server].concat());
 }


### PR DESCRIPTION
## Summary
- support custom ClientHello and ServerHello construction
- select FakeTLS or uTLS through StealthManager
- document FakeTLS configuration and usage examples
- test custom FakeTLS builder

## Testing
- `cargo test --test fake_tls -- --test-threads=1 --nocapture` *(fails: could not compile `quicfuscate`)*

------
https://chatgpt.com/codex/tasks/task_e_686d873c103083338f187044f13a3331