### PR TITLE
Improve quiche workflow handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,22 @@ The codebase is now entirely written in Rust. Development focuses on expanding f
 
 ## 🔧 Build Instructions
 
-This repository uses a Git submodule to include a patched QUIC library.
-The `libs/patched_quiche` directory is intentionally left empty to keep the
-checkout small. Fetch the sources after cloning by running the workflow
-script below.
-After cloning simply run the workflow script which fetches the sources and
-initializes the submodule automatically. The script exports `QUICHE_PATH`
-to `libs/patched_quiche/quiche` so that Cargo can find the library:
+This repository uses a Git submodule to include a patched QUIC library. The
+`libs/patched_quiche` directory is intentionally left empty to keep the checkout
+small.
+
+Simply invoke the workflow script once after cloning. It fetches the sources,
+applies all patches and builds the library automatically while exporting
+`QUICHE_PATH` so that Cargo can locate the compiled quiche:
 
 ```bash
-./scripts/quiche_workflow.sh --step fetch
+./scripts/quiche_workflow.sh --non-interactive
 ```
 
-Quick start after cloning:
+After the workflow finishes you can build the rest of the project with Cargo as
+usual:
 
 ```bash
-./scripts/quiche_workflow.sh --step fetch
 cargo build --release
 ```
 
@@ -116,7 +116,7 @@ submodule URL to a mirror that includes this commit and retry:
 
 ```bash
 git submodule set-url libs/patched_quiche <mirror-url>
-./scripts/quiche_workflow.sh --step fetch
+./scripts/quiche_workflow.sh --non-interactive
 ```
 
 The workflow script replaces the old `fetch_quiche.sh` helper and can be
@@ -132,10 +132,10 @@ export QUICHE_PATH=$(pwd)/libs/patched_quiche/quiche
 ### ⚠️ Ohne Fetch kein Build
 
 `cargo build` schlägt fehl, wenn das Verzeichnis `libs/patched_quiche/quiche`
-noch nicht existiert. Führe deshalb vor dem Bauen immer zuerst:
+noch nicht existiert. Führe deshalb vor dem Bauen immer zuerst den Workflow aus:
 
 ```bash
-./scripts/quiche_workflow.sh --step fetch
+./scripts/quiche_workflow.sh --non-interactive
 ```
 
 ### Building quiche
@@ -193,7 +193,7 @@ git submodule update --init libs/patched_quiche
 Anschließend den Workflow erneut starten:
 
 ```bash
-./scripts/quiche_workflow.sh --step fetch
+./scripts/quiche_workflow.sh --non-interactive
 ```
 
 ### Project Layout

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,23 @@
 use std::env;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
     let quiche_path = env::var("QUICHE_PATH")
         .unwrap_or_else(|_| "libs/patched_quiche/quiche".into());
+
+    // Ensure the logs directory exists so the workflow can write logs
+    let logs_dir = Path::new("libs/logs");
+    if !logs_dir.exists() {
+        if let Err(e) = fs::create_dir_all(logs_dir) {
+            println!(
+                "cargo:warning=Failed to create log directory {}: {}",
+                logs_dir.display(),
+                e
+            );
+        }
+    }
 
     if !Path::new(&quiche_path).exists() {
         println!(
@@ -22,6 +35,7 @@ fn main() {
 
         let output = Command::new("bash")
             .arg(script)
+            .arg("--non-interactive")
             .arg("--step")
             .arg("fetch")
             .arg("--step")
@@ -35,12 +49,11 @@ fn main() {
             let code = output.status.code().unwrap_or(-1);
             let stderr = String::from_utf8_lossy(&output.stderr);
             let stdout = String::from_utf8_lossy(&output.stdout);
-            panic!(
-                "Quiche workflow failed with exit code {}\nstdout:\n{}\nstderr:\n{}",
-                code,
-                stdout,
-                stderr
-            );
+            eprintln!("Quiche workflow failed with exit code {}", code);
+            eprintln!("-- stdout --\n{}", stdout);
+            eprintln!("-- stderr --\n{}", stderr);
+            eprintln!("See logs in {}", logs_dir.display());
+            panic!("Quiche workflow failed");
         } else {
             println!("cargo:warning=Workflow completed successfully");
         }


### PR DESCRIPTION
## Summary
- document automatic build step in README
- run quiche workflow non-interactively from `build.rs`
- create log directory in `build.rs`
- print more helpful workflow errors

## Testing
- `bash scripts/quiche_workflow.sh --non-interactive --step fetch --step patch --step build` *(fails: interrupted)*
- `cargo test --locked --no-run` *(fails to compile)*
- `cargo fmt -- --check` *(fails: parse error)*

------
https://chatgpt.com/codex/tasks/task_e_686d8fafc440833380b892555b0379b5