### PR TITLE
Add customizable FakeTLS responses

### DIFF
--- a/src/stealth.rs
+++ b/src/stealth.rs
@@ -51,7 +51,7 @@ use tokio::runtime::Runtime;
 use url::Url;
 
 use crate::crypto::CryptoManager; // Assumed for integration
-use crate::fake_tls;
+use crate::fake_tls::{self, ServerHelloParamsOwned};
 use crate::optimize::{self, OptimizationManager}; // Assumed for integration
 use crate::telemetry;
 use crate::tls_ffi;
@@ -182,6 +182,8 @@ pub struct FingerprintProfile {
     pub initial_max_streams_bidi: u64,
     pub max_idle_timeout: u64,
     pub client_hello: Option<Vec<u8>>,
+    pub server_hello: Option<ServerHelloParamsOwned>,
+    pub certificate: Option<Vec<u8>>,
 }
 
 impl FingerprintProfile {
@@ -481,6 +483,8 @@ impl FingerprintProfile {
         };
 
         profile.client_hello = TlsClientHelloSpoofer::load_client_hello(browser, os);
+        profile.server_hello = None;
+        profile.certificate = None;
         profile
     }
 

--- a/tests/fake_tls.rs
+++ b/tests/fake_tls.rs
@@ -37,3 +37,27 @@ fn custom_handshake_builder() {
     let server = FakeTls::server_hello_custom(sh);
     assert_eq!(FakeTls::handshake_custom(ch, sh), [hello, server].concat());
 }
+
+#[test]
+fn custom_certificate_support() {
+    let ch = ClientHelloParams {
+        tls_version: 0x0303,
+        cipher_suites: &[0x1301],
+        extensions: &[],
+    };
+    let sh = ServerHelloParams {
+        tls_version: 0x0303,
+        cipher_suite: 0x1301,
+        extensions: &[],
+    };
+    let cert = b"test";
+    let resp = FakeTls::server_response_custom(sh, cert);
+    let mut expected = FakeTls::server_hello_custom(sh);
+    expected.extend_from_slice(&FakeTls::certificate_record(cert));
+    assert_eq!(resp, expected);
+
+    let full = FakeTls::handshake_custom_with_cert(ch, sh, cert);
+    let mut exp = FakeTls::client_hello_custom(ch);
+    exp.extend_from_slice(&expected);
+    assert_eq!(full, exp);
+}


### PR DESCRIPTION
## Summary
- support custom ServerHello params and certificate for FakeTLS
- allow faster handshakes by shortening messages
- document FakeTLS custom handshake usage
- test new FakeTLS customization

## Testing
- `cargo test --all --quiet` *(fails: Quiche workflow failed, network fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686ed17dc11883339394d7cfd7ec1f59